### PR TITLE
Add upload limits for FIT and DTB uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "ostool-server"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/ostool-server/CHANGELOG.md
+++ b/ostool-server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/drivercraft/ostool/compare/ostool-server-v0.1.6...ostool-server-v0.1.7) - 2026-04-09
+
+### Added
+
+- add upload limits configuration for DTB and session files
+
 ## [0.1.6](https://github.com/drivercraft/ostool/compare/ostool-server-v0.1.5...ostool-server-v0.1.6) - 2026-04-08
 
 ### Added

--- a/ostool-server/Cargo.toml
+++ b/ostool-server/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "ostool-server"
 readme = "README.md"
 repository = "https://github.com/drivercraft/ostool"
-version = "0.1.6"
+version = "0.1.7"
 
 exclude = ["webui/node_modules/*", "webui/dist/*"]
 

--- a/ostool-server/src/api/error.rs
+++ b/ostool-server/src/api/error.rs
@@ -26,6 +26,10 @@ impl ApiError {
         Self::new(StatusCode::BAD_REQUEST, "bad_request", message)
     }
 
+    pub fn payload_too_large(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::PAYLOAD_TOO_LARGE, "payload_too_large", message)
+    }
+
     pub fn not_found(message: impl Into<String>) -> Self {
         Self::new(StatusCode::NOT_FOUND, "not_found", message)
     }

--- a/ostool-server/src/api/models.rs
+++ b/ostool-server/src/api/models.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::{
         BoardConfig, BootConfig, PowerManagementConfig, SerialConfig, SerialPortKeyKind,
-        TftpConfig, TftpNetworkConfig,
+        TftpConfig, TftpNetworkConfig, UploadLimitsConfig,
     },
     dtb_store::DtbFile,
     session::Session,
@@ -230,11 +230,13 @@ pub struct AdminServerConfigReadonly {
     pub data_dir: String,
     pub board_dir: String,
     pub dtb_dir: String,
+    pub dtb_upload_max_mib: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AdminServerConfigEditable {
     pub network: TftpNetworkConfig,
+    pub upload_limits: UploadLimitsConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -246,4 +248,5 @@ pub struct AdminServerConfigResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateServerConfigRequest {
     pub network: TftpNetworkConfig,
+    pub upload_limits: UploadLimitsConfig,
 }

--- a/ostool-server/src/api/router.rs
+++ b/ostool-server/src/api/router.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use axum::{
     Router,
-    body::Bytes,
-    extract::{Path, State, WebSocketUpgrade},
+    body::{Bytes, to_bytes},
+    extract::{Path, Request, State, WebSocketUpgrade},
     http::{HeaderMap, HeaderValue, StatusCode, header},
     response::{IntoResponse, Redirect, Response},
     routing::{delete, get, post, put},
@@ -47,6 +47,8 @@ use crate::{
     },
     web::{serve_admin_asset, serve_admin_history, serve_admin_index},
 };
+
+const DTB_UPLOAD_MAX_MIB: u32 = 10;
 
 pub fn build_router(state: AppState) -> Router {
     Router::new()
@@ -298,10 +300,11 @@ async fn get_dtb(
 
 async fn create_dtb(
     State(state): State<AppState>,
-    headers: HeaderMap,
-    body: Bytes,
+    request: Request,
 ) -> Result<(StatusCode, axum::Json<DtbFileResponse>), ApiError> {
+    let headers = request.headers();
     let dtb_name = dtb_name_header(&headers, "X-Dtb-Name")?;
+    let body = read_limited_body(request, DTB_UPLOAD_MAX_MIB, "DTB").await?;
     if body.is_empty() {
         return Err(ApiError::bad_request("DTB upload body must not be empty"));
     }
@@ -566,9 +569,9 @@ impl AdminBoardUpsertRequest {
 async fn update_dtb(
     Path(dtb_name): Path<String>,
     State(state): State<AppState>,
-    headers: HeaderMap,
-    body: Bytes,
+    request: Request,
 ) -> Result<axum::Json<DtbFileResponse>, ApiError> {
+    let headers = request.headers();
     let current_name =
         normalize_dtb_name(&dtb_name).map_err(|err| ApiError::bad_request(err.to_string()))?;
     let requested_name = headers
@@ -581,6 +584,7 @@ async fn update_dtb(
         })
         .transpose()?;
     let mut effective_name = current_name.clone();
+    let body = read_limited_body(request, DTB_UPLOAD_MAX_MIB, "DTB").await?;
 
     if requested_name.as_deref() == Some(current_name.as_str()) && body.is_empty() {
         let file = state
@@ -769,10 +773,16 @@ async fn update_server_config(
     if request.network.interface.trim().is_empty() {
         return Err(ApiError::bad_request("network.interface must not be empty"));
     }
+    if request.upload_limits.session_file_max_mib == 0 {
+        return Err(ApiError::bad_request(
+            "upload_limits.session_file_max_mib must be greater than 0",
+        ));
+    }
 
     {
         let mut config = state.config.write().await;
         config.network = request.network;
+        config.upload_limits = request.upload_limits;
     }
     state.save_config().await?;
 
@@ -1095,8 +1105,7 @@ async fn list_session_files(
 async fn put_session_file(
     Path(session_id): Path<String>,
     State(state): State<AppState>,
-    headers: HeaderMap,
-    body: Bytes,
+    request: Request,
 ) -> Result<(StatusCode, axum::Json<FileResponse>), ApiError> {
     let session = state
         .session_state(&session_id)
@@ -1111,11 +1120,14 @@ async fn put_session_file(
         .session_board(&session_id)
         .await
         .ok_or_else(|| ApiError::not_found("session board not found"))?;
+    let headers = request.headers();
     let relative_path = headers
         .get("X-File-Path")
         .and_then(|value| value.to_str().ok())
         .ok_or_else(|| ApiError::bad_request("missing X-File-Path header"))?;
     let relative_path = parse_relative_path(relative_path)?;
+    let max_mib = state.config.read().await.upload_limits.session_file_max_mib;
+    let body = read_limited_body(request, max_mib, "session file").await?;
 
     if !state.config.read().await.tftp.enabled() {
         return Err(ApiError::conflict("TFTP provider is disabled"));
@@ -1351,6 +1363,7 @@ fn readonly_server_config(config: &crate::config::ServerConfig) -> AdminServerCo
         data_dir: config.data_dir.display().to_string(),
         board_dir: config.board_dir.display().to_string(),
         dtb_dir: config.dtb_dir.display().to_string(),
+        dtb_upload_max_mib: DTB_UPLOAD_MAX_MIB,
     }
 }
 
@@ -1359,8 +1372,43 @@ fn server_config_response(config: &crate::config::ServerConfig) -> AdminServerCo
         readonly: readonly_server_config(config),
         editable: AdminServerConfigEditable {
             network: config.network.clone(),
+            upload_limits: config.upload_limits.clone(),
         },
     }
+}
+
+fn mib_to_bytes(limit_mib: u32) -> usize {
+    (limit_mib as usize) * 1024 * 1024
+}
+
+fn payload_too_large_message(label: &str, max_mib: u32) -> String {
+    format!("{label} upload body exceeds limit of {max_mib} MiB")
+}
+
+async fn read_limited_body(request: Request, max_mib: u32, label: &str) -> Result<Bytes, ApiError> {
+    let limit_bytes = mib_to_bytes(max_mib);
+    let headers = request.headers();
+    if let Some(content_length) = headers
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        && content_length > limit_bytes as u64
+    {
+        return Err(ApiError::payload_too_large(payload_too_large_message(
+            label, max_mib,
+        )));
+    }
+
+    to_bytes(request.into_body(), limit_bytes)
+        .await
+        .map_err(|err| {
+            let message = err.to_string();
+            if message.contains("length limit exceeded") {
+                ApiError::payload_too_large(payload_too_large_message(label, max_mib))
+            } else {
+                ApiError::bad_request(format!("failed to read {label} upload body: {message}"))
+            }
+        })
 }
 
 #[derive(Debug, Clone)]
@@ -1527,7 +1575,7 @@ mod tests {
     };
     use tower::util::ServiceExt;
 
-    use super::{build_router, resolve_server_network};
+    use super::{DTB_UPLOAD_MAX_MIB, build_router, mib_to_bytes, resolve_server_network};
     use crate::{
         api::models::{
             BoardPowerStatusResponse, BoardRuntimeStatusResponse, SessionDetailResponse,
@@ -1536,7 +1584,7 @@ mod tests {
         config::{
             BoardConfig, BootConfig, BuiltinTftpConfig, CustomPowerManagement,
             PowerManagementConfig, SerialConfig, SerialPortKey, SerialPortKeyKind, ServerConfig,
-            TftpConfig, VirtualPowerManagement, ZhongshengRelayPowerManagement,
+            TftpConfig, UploadLimitsConfig, VirtualPowerManagement, ZhongshengRelayPowerManagement,
         },
         session::SessionLifecycleState,
         state::BoardLeaseState,
@@ -1568,6 +1616,7 @@ mod tests {
             network: crate::TftpNetworkConfig {
                 interface: "lo".into(),
             },
+            upload_limits: UploadLimitsConfig::default(),
         }
     }
 
@@ -1791,7 +1840,9 @@ mod tests {
                     .method("PUT")
                     .uri("/api/v1/admin/server-config")
                     .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(r#"{"network":{"interface":"lo"}}"#))
+                    .body(Body::from(
+                        r#"{"network":{"interface":"lo"},"upload_limits":{"session_file_max_mib":32}}"#,
+                    ))
                     .unwrap(),
             )
             .await
@@ -1801,6 +1852,11 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(value["editable"]["network"]["interface"], "lo");
+        assert_eq!(
+            value["editable"]["upload_limits"]["session_file_max_mib"],
+            32
+        );
+        assert_eq!(value["readonly"]["dtb_upload_max_mib"], DTB_UPLOAD_MAX_MIB);
         assert!(value["readonly"]["listen_addr"].is_string());
     }
 
@@ -2693,6 +2749,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn admin_dtb_endpoints_enforce_upload_limit() {
+        let app = test_router().await;
+        let oversized = vec![b'x'; mib_to_bytes(DTB_UPLOAD_MAX_MIB) + 1];
+
+        let create_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/admin/dtbs")
+                    .header("X-Dtb-Name", "oversized.dtb")
+                    .body(Body::from(oversized.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let create_body = to_bytes(create_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let create_value: serde_json::Value = serde_json::from_slice(&create_body).unwrap();
+        assert_eq!(create_value["code"], "payload_too_large");
+        assert_eq!(
+            create_value["message"],
+            format!("DTB upload body exceeds limit of {DTB_UPLOAD_MAX_MIB} MiB")
+        );
+
+        assert_eq!(
+            upload_dtb(&app, "replace-me.dtb", "dtb-v1").await,
+            StatusCode::CREATED
+        );
+        let replace_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/admin/dtbs/replace-me.dtb")
+                    .body(Body::from(oversized))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(replace_response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
     async fn renaming_dtb_updates_board_references_and_referenced_dtb_cannot_be_deleted() {
         let app = test_router().await;
         assert_eq!(
@@ -3051,6 +3153,74 @@ mod tests {
         assert_eq!(
             files[1]["relative_path"],
             format!("ostool/sessions/{session_id}/boot/dtb/board.dtb")
+        );
+    }
+
+    #[tokio::test]
+    async fn session_file_upload_enforces_dynamic_limit() {
+        let app = test_router().await;
+        assert_eq!(
+            create_board(
+                &app,
+                serde_json::to_value(sample_board("limited-files")).unwrap()
+            )
+            .await,
+            StatusCode::CREATED
+        );
+        let session_id = create_session(&app, "rk3568").await;
+
+        let initial_upload = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/sessions/{session_id}/files"))
+                    .header("X-File-Path", "boot/Image")
+                    .body(Body::from(vec![b'a'; 1024 * 1024]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(initial_upload.status(), StatusCode::CREATED);
+
+        let update_limit = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/admin/server-config")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"network":{"interface":"lo"},"upload_limits":{"session_file_max_mib":1}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(update_limit.status(), StatusCode::OK);
+
+        let oversized = vec![b'b'; 1024 * 1024 + 1];
+        let oversized_upload = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/sessions/{session_id}/files"))
+                    .header("X-File-Path", "boot/Image")
+                    .body(Body::from(oversized))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(oversized_upload.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let oversized_body = to_bytes(oversized_upload.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let oversized_value: serde_json::Value = serde_json::from_slice(&oversized_body).unwrap();
+        assert_eq!(oversized_value["code"], "payload_too_large");
+        assert_eq!(
+            oversized_value["message"],
+            "session file upload body exceeds limit of 1 MiB"
         );
     }
 

--- a/ostool-server/src/config.rs
+++ b/ostool-server/src/config.rs
@@ -21,6 +21,8 @@ pub struct ServerConfig {
     pub dtb_dir: PathBuf,
     pub tftp: TftpConfig,
     pub network: TftpNetworkConfig,
+    #[serde(default)]
+    pub upload_limits: UploadLimitsConfig,
 }
 
 impl Default for ServerConfig {
@@ -56,6 +58,7 @@ impl ServerConfig {
             dtb_dir,
             tftp,
             network: TftpNetworkConfig::default(),
+            upload_limits: UploadLimitsConfig::default(),
         }
     }
 
@@ -165,7 +168,23 @@ impl ServerConfig {
                 "network.interface must be configured or auto-detected from a non-loopback interface"
             );
         }
+        if self.upload_limits.session_file_max_mib == 0 {
+            bail!("upload_limits.session_file_max_mib must be greater than 0");
+        }
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct UploadLimitsConfig {
+    pub session_file_max_mib: u32,
+}
+
+impl Default for UploadLimitsConfig {
+    fn default() -> Self {
+        Self {
+            session_file_max_mib: 64,
+        }
     }
 }
 
@@ -431,7 +450,32 @@ mod tests {
         let decoded: ServerConfig = toml::from_str(&encoded).unwrap();
         assert_eq!(decoded.listen_addr, SocketAddr::from(([0, 0, 0, 0], 2999)));
         assert_eq!(decoded.network.interface, "");
+        assert_eq!(decoded.upload_limits.session_file_max_mib, 64);
         assert!(decoded.dtb_dir.ends_with("dtbs"));
+    }
+
+    #[test]
+    fn server_config_defaults_upload_limits_when_missing() {
+        let decoded: ServerConfig = toml::from_str(
+            r#"
+listen_addr = "0.0.0.0:2999"
+data_dir = ".ostool-server"
+board_dir = ".ostool-server/boards"
+dtb_dir = ".ostool-server/dtbs"
+
+[tftp]
+provider = "builtin"
+enabled = true
+root_dir = ".ostool-server/tftp-root"
+bind_addr = "0.0.0.0:69"
+
+[network]
+interface = "eth0"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(decoded.upload_limits.session_file_max_mib, 64);
     }
 
     #[test]
@@ -457,6 +501,7 @@ mod tests {
 
         let content = std::fs::read_to_string(path).unwrap();
         assert!(content.contains("listen_addr = \"0.0.0.0:2999\""));
+        assert!(content.contains("session_file_max_mib = 64"));
     }
 
     #[test]

--- a/ostool-server/src/lib.rs
+++ b/ostool-server/src/lib.rs
@@ -17,7 +17,7 @@ pub use api::router::build_router;
 pub use config::{
     BoardConfig, BootConfig, BuiltinTftpConfig, CustomPowerManagement, PowerManagementConfig,
     PxeProfile, SerialConfig, SerialPortKey, SerialPortKeyKind, ServerConfig, SystemTftpdHpaConfig,
-    TftpConfig, TftpNetworkConfig, UbootProfile, VirtualPowerManagement,
+    TftpConfig, TftpNetworkConfig, UbootProfile, UploadLimitsConfig, VirtualPowerManagement,
     ZhongshengRelayPowerManagement,
 };
 pub use dtb_store::{DtbFile, DtbStore};

--- a/ostool-server/tests/session_ws_lifecycle.rs
+++ b/ostool-server/tests/session_ws_lifecycle.rs
@@ -13,8 +13,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use futures_util::{SinkExt, StreamExt};
 use ostool_server::{
     BoardConfig, BootConfig, BuiltinTftpConfig, PowerManagementConfig, SerialConfig, SerialPortKey,
-    SerialPortKeyKind, ServerConfig, TftpConfig, UbootProfile, VirtualPowerManagement,
-    build_app_state, build_router,
+    SerialPortKeyKind, ServerConfig, TftpConfig, UbootProfile, UploadLimitsConfig,
+    VirtualPowerManagement, build_app_state, build_router,
     tftp::service::{TftpManager, build_tftp_manager},
 };
 use reqwest::StatusCode;
@@ -116,6 +116,7 @@ fn spawn_test_server(root: &Path, serial_port: String) -> Result<TestServerHandl
         network: ostool_server::TftpNetworkConfig {
             interface: "lo".into(),
         },
+        upload_limits: UploadLimitsConfig::default(),
     };
     std::fs::write(&config_path, toml::to_string_pretty(&config)?)
         .with_context(|| format!("failed to write {}", config_path.display()))?;

--- a/ostool-server/webui/src/types/api.ts
+++ b/ostool-server/webui/src/types/api.ts
@@ -30,6 +30,10 @@ export interface TftpNetworkConfig {
   interface: string;
 }
 
+export interface UploadLimitsConfig {
+  session_file_max_mib: number;
+}
+
 export interface TftpStatus {
   provider: string;
   enabled: boolean;
@@ -178,10 +182,12 @@ export interface AdminServerConfigReadonly {
   data_dir: string;
   board_dir: string;
   dtb_dir: string;
+  dtb_upload_max_mib: number;
 }
 
 export interface AdminServerConfigEditable {
   network: TftpNetworkConfig;
+  upload_limits: UploadLimitsConfig;
 }
 
 export interface AdminServerConfigResponse {
@@ -191,6 +197,7 @@ export interface AdminServerConfigResponse {
 
 export interface UpdateServerConfigRequest {
   network: TftpNetworkConfig;
+  upload_limits: UploadLimitsConfig;
 }
 
 export interface BootProfileResponse {

--- a/ostool-server/webui/src/views/BoardEditorView.vue
+++ b/ostool-server/webui/src/views/BoardEditorView.vue
@@ -49,6 +49,8 @@ const saving = ref(false);
 const deleting = ref(false);
 const refreshingSerials = ref(false);
 const uploadingDtb = ref(false);
+const DTB_UPLOAD_MAX_MIB = 10;
+const DTB_UPLOAD_MAX_BYTES = DTB_UPLOAD_MAX_MIB * 1024 * 1024;
 const validationError = ref("");
 const form = ref<BoardEditorFormState>(defaultFormState());
 const serialPorts = ref<SerialPortSummary[]>([]);
@@ -467,6 +469,13 @@ function onDtbFileChange(event: Event) {
   }
 }
 
+function validateDtbUploadFile(file: File | null): string | null {
+  if (file && file.size > DTB_UPLOAD_MAX_BYTES) {
+    return `DTB 文件大小不能超过 ${DTB_UPLOAD_MAX_MIB} MiB`;
+  }
+  return null;
+}
+
 function openDtbUploadModal() {
   showingDtbUploadModal.value = true;
 }
@@ -483,6 +492,11 @@ function closeDtbUploadModal() {
 async function uploadDtbAndSelect() {
   if (!dtbUploadFile.value) {
     ui.setError("请选择要上传的 DTB 文件");
+    return;
+  }
+  const sizeError = validateDtbUploadFile(dtbUploadFile.value);
+  if (sizeError) {
+    ui.setError(sizeError);
     return;
   }
   const dtbName = dtbUploadName.value.trim() || dtbUploadFile.value.name;
@@ -838,6 +852,7 @@ onMounted(() => {
           />
         </label>
       </div>
+      <p class="muted">DTB 上传上限固定为 {{ DTB_UPLOAD_MAX_MIB }} MiB。</p>
 
       <div class="toolbar-actions modal-actions">
         <button class="ghost-button" type="button" :disabled="uploadingDtb" @click="closeDtbUploadModal">

--- a/ostool-server/webui/src/views/DtbView.vue
+++ b/ostool-server/webui/src/views/DtbView.vue
@@ -18,6 +18,8 @@ const editingDtbName = ref<string | null>(null);
 const editDtbName = ref("");
 const editDtbFile = ref<File | null>(null);
 const editDtbFileInput = ref<HTMLInputElement | null>(null);
+const DTB_UPLOAD_MAX_MIB = 10;
+const DTB_UPLOAD_MAX_BYTES = DTB_UPLOAD_MAX_MIB * 1024 * 1024;
 
 function formatSize(size: number): string {
   if (size < 1024) {
@@ -31,6 +33,13 @@ function formatSize(size: number): string {
 
 function formatTime(value: string): string {
   return new Date(value).toLocaleString("zh-CN", { hour12: false });
+}
+
+function validateDtbFileSize(file: File | null): string | null {
+  if (file && file.size > DTB_UPLOAD_MAX_BYTES) {
+    return `DTB 文件大小不能超过 ${DTB_UPLOAD_MAX_MIB} MiB`;
+  }
+  return null;
 }
 
 async function loadDtbs() {
@@ -66,6 +75,11 @@ function onReplaceFileChange(event: Event) {
 async function createDtb() {
   if (!newDtbFile.value) {
     ui.setError("请选择要上传的 DTB 文件");
+    return;
+  }
+  const sizeError = validateDtbFileSize(newDtbFile.value);
+  if (sizeError) {
+    ui.setError(sizeError);
     return;
   }
   const name = newDtbName.value.trim() || newDtbFile.value.name;
@@ -116,6 +130,11 @@ async function saveDtb() {
   }
   const nextName = editDtbName.value.trim();
   const replaceFile = editDtbFile.value;
+  const sizeError = validateDtbFileSize(replaceFile);
+  if (sizeError) {
+    ui.setError(sizeError);
+    return;
+  }
   if (!nextName) {
     ui.setError("DTB 文件名不能为空");
     return;
@@ -180,6 +199,7 @@ onMounted(() => {
 
       <section class="form-section">
         <h4>上传新 DTB</h4>
+        <p class="muted">单个 DTB 文件最大支持 {{ DTB_UPLOAD_MAX_MIB }} MiB。</p>
         <div class="form-grid three-columns">
           <label class="field">
             <span>文件名</span>
@@ -273,6 +293,7 @@ onMounted(() => {
           />
         </label>
       </div>
+      <p class="muted">替换上传时同样受 {{ DTB_UPLOAD_MAX_MIB }} MiB 限制。</p>
 
       <div class="toolbar-actions modal-actions">
         <button class="ghost-button" :disabled="updatingName === editingDtbName" @click="closeEditDtb">

--- a/ostool-server/webui/src/views/ServerView.test.ts
+++ b/ostool-server/webui/src/views/ServerView.test.ts
@@ -1,0 +1,97 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getServerConfig = vi.fn();
+const updateServerConfig = vi.fn();
+const listNetworkInterfaces = vi.fn();
+const uiStore = {
+  clearMessages: vi.fn(),
+  setError: vi.fn(),
+  setSuccess: vi.fn(),
+};
+
+vi.mock("@/api/client", () => ({
+  api: {
+    getServerConfig,
+    updateServerConfig,
+    listNetworkInterfaces,
+  },
+}));
+
+vi.mock("@/stores/ui", () => ({
+  useUiStore: () => uiStore,
+}));
+
+function makeConfig() {
+  return {
+    readonly: {
+      listen_addr: "0.0.0.0:2999",
+      data_dir: "/var/lib/ostool-server",
+      board_dir: "/var/lib/ostool-server/boards",
+      dtb_dir: "/var/lib/ostool-server/dtbs",
+      dtb_upload_max_mib: 10,
+    },
+    editable: {
+      network: {
+        interface: "eth0",
+      },
+      upload_limits: {
+        session_file_max_mib: 64,
+      },
+    },
+  };
+}
+
+describe("ServerView", () => {
+  beforeEach(() => {
+    getServerConfig.mockReset();
+    updateServerConfig.mockReset();
+    listNetworkInterfaces.mockReset();
+    uiStore.clearMessages.mockReset();
+    uiStore.setError.mockReset();
+    uiStore.setSuccess.mockReset();
+
+    getServerConfig.mockResolvedValue(makeConfig());
+    listNetworkInterfaces.mockResolvedValue([
+      {
+        name: "eth0",
+        label: "eth0",
+        ipv4_addresses: ["192.168.1.10"],
+        netmask: "255.255.255.0",
+        loopback: false,
+      },
+    ]);
+    updateServerConfig.mockImplementation(async (payload) => ({
+      ...makeConfig(),
+      editable: payload,
+    }));
+  });
+
+  it("loads config, renders fixed DTB limit, and saves upload limits", async () => {
+    const ServerView = (await import("./ServerView.vue")).default;
+    const wrapper = mount(ServerView);
+    await flushPromises();
+
+    expect(getServerConfig).toHaveBeenCalledTimes(1);
+    expect(listNetworkInterfaces).toHaveBeenCalledTimes(1);
+    expect(wrapper.text()).toContain("DTB 上传上限");
+    expect(wrapper.text()).toContain("10 MiB");
+
+    const numberInput = wrapper.get('input[type="number"]');
+    await numberInput.setValue("32");
+
+    const saveButton = wrapper.findAll("button").find((button) => button.text() === "保存配置");
+    await saveButton!.trigger("click");
+    await flushPromises();
+
+    expect(updateServerConfig).toHaveBeenCalledWith({
+      network: {
+        interface: "eth0",
+      },
+      upload_limits: {
+        session_file_max_mib: 32,
+      },
+    });
+    expect(uiStore.setSuccess).toHaveBeenCalledWith("已保存 Server 安全配置");
+  });
+});

--- a/ostool-server/webui/src/views/ServerView.vue
+++ b/ostool-server/webui/src/views/ServerView.vue
@@ -46,10 +46,18 @@ async function saveConfig() {
     return;
   }
 
+  const sessionFileMaxMib = Number(config.value.editable.upload_limits.session_file_max_mib);
+  if (!Number.isFinite(sessionFileMaxMib) || sessionFileMaxMib < 1) {
+    ui.setError("Session 文件上传上限必须是大于等于 1 的整数 MiB");
+    return;
+  }
+  config.value.editable.upload_limits.session_file_max_mib = Math.trunc(sessionFileMaxMib);
+
   saving.value = true;
   try {
     config.value = await api.updateServerConfig({
       network: config.value.editable.network,
+      upload_limits: config.value.editable.upload_limits,
     });
     ui.setSuccess("已保存 Server 安全配置");
   } catch (error) {
@@ -110,6 +118,14 @@ onMounted(() => {
                 <dt>板子目录</dt>
                 <dd>{{ config.readonly.board_dir }}</dd>
               </div>
+              <div>
+                <dt>DTB 目录</dt>
+                <dd>{{ config.readonly.dtb_dir }}</dd>
+              </div>
+              <div>
+                <dt>DTB 上传上限</dt>
+                <dd>{{ config.readonly.dtb_upload_max_mib }} MiB</dd>
+              </div>
             </dl>
           </section>
 
@@ -136,9 +152,22 @@ onMounted(() => {
                   </button>
                 </div>
               </label>
+              <label class="field">
+                <span>Session 文件上传上限</span>
+                <input
+                  v-model.number="config.editable.upload_limits.session_file_max_mib"
+                  type="number"
+                  min="1"
+                  step="1"
+                />
+              </label>
             </div>
             <p class="muted">
-              服务级网络配置保存后立即生效；`listen_addr`、`data_dir`、`board_dir` 仍保持只读，避免运行中修改导致服务行为不稳定。
+              服务级网络配置和 session 文件上传上限保存后会立即作用于新的请求；DTB 上传上限固定为
+              {{ config.readonly.dtb_upload_max_mib }} MiB。
+            </p>
+            <p class="muted">
+              `listen_addr`、`data_dir`、`board_dir`、`dtb_dir` 仍保持只读，避免运行中修改导致服务行为不稳定。
             </p>
           </section>
         </div>


### PR DESCRIPTION
## Summary

- add configurable session file upload limits to ostool-server with a default of 64 MiB
- enforce a fixed 10 MiB limit for DTB uploads across API and WebUI
- surface the limits in server settings and add tests for dynamic reload and payload-too-large responses

## Root Cause

ostool-server accepted upload bodies through axum Bytes extraction, which applies a default 2 MiB request-body limit. FIT uploads for axvisor on orangepi-5-plus exceeded that limit, so the server rejected the request before the session file was written.

## Impact

- FIT image uploads can now succeed for larger board-test artifacts without restarting the server after config changes
- DTB uploads fail fast with a clear 413 error when they exceed the fixed limit
- the WebUI now shows and validates the relevant upload limits

## Validation

- cargo test -p ostool-server
- pnpm test -- --run ServerView.test.ts DtbView.test.ts BoardEditorView.test.ts
