### PR TITLE
fix(uboot): honor board timeout in serial interaction stage

### DIFF
--- a/ostool/src/board/config.rs
+++ b/ostool/src/board/config.rs
@@ -20,6 +20,7 @@ pub struct BoardRunConfig {
     pub uboot_cmd: Option<Vec<String>>,
     pub shell_prefix: Option<String>,
     pub shell_init_cmd: Option<String>,
+    pub timeout: Option<u64>,
     pub server: Option<String>,
     pub port: Option<u16>,
 }
@@ -204,6 +205,7 @@ fail_regex = ["panic"]
 uboot_cmd = [" run bootcmd "]
 shell_prefix = " login: "
 shell_init_cmd = " root "
+timeout = 15
 server = "10.0.0.2"
 port = 9000
 "#,
@@ -217,6 +219,7 @@ port = 9000
         assert_eq!(config.uboot_cmd, Some(vec!["run bootcmd".to_string()]));
         assert_eq!(config.shell_prefix.as_deref(), Some("login:"));
         assert_eq!(config.shell_init_cmd.as_deref(), Some("root"));
+        assert_eq!(config.timeout, Some(15));
         assert_eq!(
             config.resolve_server(
                 Some("127.0.0.1"),
@@ -277,6 +280,7 @@ port = 9000
 board_type = " rk3568 "
 shell_prefix = " login: "
 shell_init_cmd = " root "
+timeout = 8
 "#,
         )
         .unwrap();
@@ -294,6 +298,7 @@ shell_init_cmd = " root "
         assert_eq!(config.board_type, "rk3568");
         assert_eq!(config.shell_prefix.as_deref(), Some("login:"));
         assert_eq!(config.shell_init_cmd.as_deref(), Some("root"));
+        assert_eq!(config.timeout, Some(8));
     }
 
     #[tokio::test]

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -83,7 +83,8 @@ pub struct UbootConfig {
     pub shell_prefix: Option<String>,
     /// Command sent once after `shell_prefix` is detected.
     pub shell_init_cmd: Option<String>,
-    /// Timeout in seconds after entering kernel output. `None` or `0` disables the timeout.
+    /// Timeout in seconds after entering the serial terminal interaction stage. `None` or `0`
+    /// disables the timeout.
     pub timeout: Option<u64>,
     #[serde(flatten)]
     pub local: LocalUbootConfig,
@@ -114,6 +115,7 @@ impl UbootConfig {
             uboot_cmd: config.uboot_cmd.clone(),
             shell_prefix: config.shell_prefix.clone(),
             shell_init_cmd: config.shell_init_cmd.clone(),
+            timeout: config.timeout,
             ..Default::default()
         }
     }
@@ -1670,12 +1672,14 @@ timeout = 0
             uboot_cmd: Some(vec!["run ab_select_cmd".into(), "run avb_boot".into()]),
             shell_prefix: Some("login:".into()),
             shell_init_cmd: Some("root".into()),
+            timeout: Some(12),
             server: None,
             port: None,
         });
 
         assert_eq!(config.dtb_file.as_deref(), Some("/tmp/board.dtb"));
         assert_eq!(config.success_regex, vec!["ok"]);
+        assert_eq!(config.timeout, Some(12));
         assert_eq!(
             config.uboot_cmd,
             Some(vec![


### PR DESCRIPTION
## What changed

This updates board-driven U-Boot timeout handling so `.board.toml` `timeout` is propagated into the U-Boot runtime config.

It also keeps the timeout semantics aligned with the existing terminal behavior: the timeout starts when the serial terminal interaction stage begins, not during earlier U-Boot setup, probing, or image staging.

## Why

`ostool board` did not honor the configured timeout because `BoardRunConfig` was not carrying `timeout` into `UbootConfig`.

That meant board runs silently ignored the timeout value even though direct U-Boot config parsing already supported it.

## Impact

Users running `ostool board` can now configure `timeout` in `.board.toml` and have it take effect consistently.

The countdown starts from the later serial interaction stage, which matches the existing behavior of the terminal runner.

## Validation

- `cargo test -p ostool`
