### PR TITLE
refactor(tool): 收敛构建配置与运行产物边界

### DIFF
--- a/ostool/src/artifact/mod.rs
+++ b/ostool/src/artifact/mod.rs
@@ -1,1 +1,4 @@
+//! Runtime artifact preparation and state tracking.
+
 pub(crate) mod runtime;
+pub(crate) mod state;

--- a/ostool/src/artifact/runtime.rs
+++ b/ostool/src/artifact/runtime.rs
@@ -1,3 +1,9 @@
+//! Runtime artifact preparation helpers.
+//!
+//! The build pipeline may produce an executable in Cargo's artifact directory
+//! or receive a custom ELF path. This module normalizes that input into the ELF
+//! and optional BIN files consumed by QEMU, U-Boot, TFTP, and board runners.
+
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -9,16 +15,25 @@ use object::{Architecture, Object};
 
 use crate::{process::ProcessContext, utils::PathResultExt};
 
+/// Options controlling how an input ELF is prepared for runtime use.
 pub(crate) struct RuntimeArtifactOptions {
+    /// Input ELF path produced by Cargo or supplied by a custom build.
     pub(crate) elf_path: PathBuf,
+    /// Whether to also produce a raw BIN image.
     pub(crate) to_bin: bool,
+    /// Optional directory for the generated BIN image.
     pub(crate) bin_dir: Option<PathBuf>,
+    /// Whether to preserve debug information when producing a BIN image.
     pub(crate) debug: bool,
+    /// Cargo artifact directory reported by `--message-format=json`, when known.
     pub(crate) cargo_artifact_dir: Option<PathBuf>,
+    /// Whether to copy the input ELF into a stripped runtime `.elf` file first.
     pub(crate) strip_elf: bool,
+    /// Objcopy executable used for ELF/BIN materialization.
     pub(crate) objcopy_program: PathBuf,
 }
 
+/// Runtime artifacts prepared from a single input ELF.
 pub(crate) struct PreparedRuntimeArtifacts {
     elf: PathBuf,
     bin: Option<PathBuf>,
@@ -28,27 +43,33 @@ pub(crate) struct PreparedRuntimeArtifacts {
 }
 
 impl PreparedRuntimeArtifacts {
+    /// Returns the runtime ELF path.
     pub(crate) fn elf(&self) -> &Path {
         &self.elf
     }
 
+    /// Returns the runtime BIN path, when one was generated.
     pub(crate) fn bin(&self) -> Option<&Path> {
         self.bin.as_deref()
     }
 
+    /// Returns the Cargo artifact directory that produced the input ELF.
     pub(crate) fn cargo_artifact_dir(&self) -> Option<&Path> {
         self.cargo_artifact_dir.as_deref()
     }
 
+    /// Returns the directory containing the artifact consumed by runners.
     pub(crate) fn runtime_artifact_dir(&self) -> Option<&Path> {
         self.runtime_artifact_dir.as_deref()
     }
 
+    /// Returns the architecture detected from the input ELF.
     pub(crate) fn arch(&self) -> Option<Architecture> {
         self.arch
     }
 }
 
+/// Prepares runtime ELF/BIN artifacts from a Cargo or custom-build ELF.
 pub(crate) fn prepare_runtime_artifacts(
     context: &ProcessContext,
     options: RuntimeArtifactOptions,

--- a/ostool/src/artifact/state.rs
+++ b/ostool/src/artifact/state.rs
@@ -1,0 +1,65 @@
+//! Runtime artifact state shared by build orchestration and runners.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
+
+use crate::artifact::runtime::PreparedRuntimeArtifacts;
+
+/// Runtime artifacts prepared from a build output.
+#[derive(Default, Clone, Debug)]
+pub struct OutputArtifacts {
+    /// Path to the built ELF file.
+    elf: Option<PathBuf>,
+    /// Path to the converted binary file.
+    bin: Option<PathBuf>,
+    /// Cargo-reported directory containing the original ELF artifact.
+    cargo_artifact_dir: Option<PathBuf>,
+    /// Directory containing the runtime artifact consumed by runners.
+    runtime_artifact_dir: Option<PathBuf>,
+}
+
+impl OutputArtifacts {
+    /// Returns the stripped runtime ELF path, when one has been prepared.
+    pub fn elf(&self) -> Option<&Path> {
+        self.elf.as_deref()
+    }
+
+    /// Returns the raw binary image path, when one has been prepared.
+    pub fn bin(&self) -> Option<&Path> {
+        self.bin.as_deref()
+    }
+
+    /// Returns the Cargo artifact directory that produced the runtime ELF.
+    pub fn cargo_artifact_dir(&self) -> Option<&Path> {
+        self.cargo_artifact_dir.as_deref()
+    }
+
+    /// Returns the directory containing the runtime artifacts consumed by runners.
+    pub fn runtime_artifact_dir(&self) -> Option<&Path> {
+        self.runtime_artifact_dir.as_deref()
+    }
+
+    /// Returns the preferred image path for runners that can load BIN or ELF.
+    pub(crate) fn runtime_image(&self) -> Option<&Path> {
+        self.bin().or_else(|| self.elf())
+    }
+
+    /// Returns the prepared BIN path or the caller-provided error message.
+    pub(crate) fn require_bin(&self, message: &'static str) -> anyhow::Result<&Path> {
+        self.bin().ok_or_else(|| anyhow!(message))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_runtime_artifact_dir(&mut self, path: PathBuf) {
+        self.runtime_artifact_dir = Some(path);
+    }
+
+    /// Replaces artifact state from a prepared runtime artifact set.
+    pub(crate) fn apply_prepared_runtime_artifacts(&mut self, prepared: &PreparedRuntimeArtifacts) {
+        self.elf = Some(prepared.elf().to_path_buf());
+        self.bin = prepared.bin().map(PathBuf::from);
+        self.cargo_artifact_dir = prepared.cargo_artifact_dir().map(PathBuf::from);
+        self.runtime_artifact_dir = prepared.runtime_artifact_dir().map(PathBuf::from);
+    }
+}

--- a/ostool/src/build/cargo_pipeline.rs
+++ b/ostool/src/build/cargo_pipeline.rs
@@ -623,9 +623,9 @@ mod tests {
             outcome.resolved_artifact().elf_path(),
             target_dir.join("kernel")
         );
-        assert!(tool.ctx.artifacts.elf.is_none());
-        assert!(tool.ctx.artifacts.bin.is_none());
-        assert!(tool.ctx.artifacts.cargo_artifact_dir.is_none());
-        assert!(tool.ctx.artifacts.runtime_artifact_dir.is_none());
+        assert!(tool.ctx.artifacts.elf().is_none());
+        assert!(tool.ctx.artifacts.bin().is_none());
+        assert!(tool.ctx.artifacts.cargo_artifact_dir().is_none());
+        assert!(tool.ctx.artifacts.runtime_artifact_dir().is_none());
     }
 }

--- a/ostool/src/build/config_hooks.rs
+++ b/ostool/src/build/config_hooks.rs
@@ -1,0 +1,596 @@
+//! Menuconfig hooks for Cargo build configuration fields.
+//!
+//! The hooks keep the interactive `.build.toml` editor close to Cargo metadata:
+//! package and feature choices come from the selected workspace, and target
+//! candidates prefer docs.rs metadata before falling back to rustup.
+
+use std::{path::Path, process::Command, sync::Arc};
+
+use anyhow::{Context, anyhow, bail};
+use jkconfig::data::{
+    ElementHook, HookContext, HookFlow, HookOption, MessageLevel, MultiSelectBinding,
+    MultiSelectSpec, SingleSelectBinding, SingleSelectSpec,
+};
+
+/// Builds the hook set used by the `.build.toml` menuconfig editor.
+pub fn build_config_hooks(workspace_dir: &Path) -> Vec<ElementHook> {
+    vec![
+        feature_select_hook(workspace_dir),
+        package_select_hook(workspace_dir),
+        target_select_hook(workspace_dir),
+    ]
+}
+
+fn feature_select_hook(workspace_dir: &Path) -> ElementHook {
+    let path = "system.features";
+    let cargo_toml = workspace_dir.join("Cargo.toml");
+    ElementHook {
+        path: path.into(),
+        callback: Arc::new(move |ctx: &mut HookContext<'_>, path| {
+            let package = ctx
+                .get_string("system.package")?
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            if package.is_empty() {
+                ctx.show_message(
+                    jkconfig::data::MessageLevel::Warning,
+                    "Select a package before editing features.",
+                );
+                return Ok(HookFlow::Consumed);
+            }
+
+            let feature_options = collect_feature_options(&cargo_toml, &package)?;
+            let options = feature_options
+                .into_iter()
+                .map(|feature| HookOption::new(feature.clone(), feature))
+                .collect();
+
+            ctx.present_multi_select(MultiSelectSpec {
+                title: format!("Features for {package}"),
+                help: Some(
+                    "Space toggle  Enter apply. Dependency features use dep_name/feature.".into(),
+                ),
+                options,
+                selected: ctx.get_strings(path.clone())?,
+                min_selected: None,
+                max_selected: None,
+                binding: MultiSelectBinding::SetStringArray { path: path.clone() },
+            })?;
+
+            Ok(HookFlow::Consumed)
+        }),
+    }
+}
+
+fn package_select_hook(workspace_dir: &Path) -> ElementHook {
+    let path = "system.package";
+    let cargo_toml = workspace_dir.join("Cargo.toml");
+
+    ElementHook {
+        path: path.into(),
+        callback: Arc::new(move |ctx: &mut HookContext<'_>, path| {
+            let mut items = Vec::new();
+            if let Ok(metadata) = cargo_metadata::MetadataCommand::new()
+                .manifest_path(&cargo_toml)
+                .no_deps()
+                .exec()
+            {
+                for pkg in &metadata.packages {
+                    items.push(pkg.name.to_string());
+                }
+            }
+
+            let options = items
+                .into_iter()
+                .map(|item| HookOption::new(item.clone(), item))
+                .collect();
+            ctx.present_single_select(SingleSelectSpec {
+                title: "Select Package".into(),
+                help: Some("Choose the Cargo package used by the build config.".into()),
+                options,
+                initial: ctx.get_string(path.clone())?,
+                allow_clear: false,
+                binding: SingleSelectBinding::SetString { path: path.clone() },
+            })?;
+            Ok(HookFlow::Consumed)
+        }),
+    }
+}
+
+fn target_select_hook(workspace_dir: &Path) -> ElementHook {
+    let path = "system.target";
+    let cargo_toml = workspace_dir.join("Cargo.toml");
+
+    ElementHook {
+        path: path.into(),
+        callback: Arc::new(move |ctx: &mut HookContext<'_>, path| {
+            let package = ctx
+                .get_string("system.package")?
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            let current_target = ctx.get_string(path.clone())?;
+
+            let mut warnings = Vec::new();
+            let (options, help) = if package.is_empty() {
+                fallback_rustup_targets()?
+            } else {
+                match collect_package_doc_targets(&cargo_toml, &package) {
+                    Ok(Some(doc_targets)) => (
+                        build_target_options(TargetCandidateSet::DocsRs(&doc_targets)),
+                        "Select a target declared by the selected package docs.rs metadata."
+                            .to_string(),
+                    ),
+                    Ok(None) => fallback_rustup_targets()?,
+                    Err(err) => {
+                        warnings.push(format!(
+                            "Failed to inspect docs.rs targets for package '{package}': {err}"
+                        ));
+                        fallback_rustup_targets()?
+                    }
+                }
+            };
+
+            if options.is_empty() {
+                bail!("No target candidates available for selection");
+            }
+
+            for warning in warnings {
+                ctx.show_message(MessageLevel::Warning, warning);
+            }
+
+            ctx.present_single_select(SingleSelectSpec {
+                title: "Select Target".into(),
+                help: Some(help),
+                options,
+                initial: current_target,
+                allow_clear: false,
+                binding: SingleSelectBinding::SetString { path: path.clone() },
+            })?;
+
+            Ok(HookFlow::Consumed)
+        }),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RustupTargetOption {
+    triple: String,
+    installed: bool,
+}
+
+enum TargetCandidateSet<'targets> {
+    DocsRs(&'targets [String]),
+    Rustup(&'targets [RustupTargetOption]),
+}
+
+fn fallback_rustup_targets() -> anyhow::Result<(Vec<HookOption>, String)> {
+    let rustup_targets = collect_rustup_targets()?;
+    if rustup_targets.is_empty() {
+        bail!("No Rust targets available from `rustup target list`");
+    }
+    Ok((
+        build_target_options(TargetCandidateSet::Rustup(&rustup_targets)),
+        "Package has no docs.rs targets; showing rustup targets.".to_string(),
+    ))
+}
+
+/// Collect feature names for the selected package and its workspace dependencies.
+///
+/// Metadata is loaded with `cargo_metadata::MetadataCommand::no_deps()`, so
+/// dependency feature options are collected only when the dependency is another
+/// workspace member. Features from external crates are not included.
+fn collect_feature_options(
+    manifest_path: &Path,
+    package_name: &str,
+) -> anyhow::Result<Vec<String>> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .manifest_path(manifest_path)
+        .no_deps()
+        .exec()?;
+    let Some(pkg) = metadata
+        .packages
+        .iter()
+        .find(|pkg| pkg.name == package_name)
+    else {
+        bail!(
+            "package '{package_name}' not found in {}",
+            manifest_path.display()
+        );
+    };
+
+    let mut features = pkg.features.keys().cloned().collect::<Vec<_>>();
+    features.sort();
+
+    for dependency in &pkg.dependencies {
+        let Some(dep_pkg) = metadata
+            .packages
+            .iter()
+            .find(|candidate| candidate.name == dependency.name)
+        else {
+            continue;
+        };
+        let mut dep_features = dep_pkg.features.keys().cloned().collect::<Vec<_>>();
+        dep_features.sort();
+        features.extend(
+            dep_features
+                .into_iter()
+                .map(|feature| format!("{}/{}", dependency.name, feature)),
+        );
+    }
+
+    Ok(features)
+}
+
+fn collect_package_doc_targets(
+    manifest_path: &Path,
+    package_name: &str,
+) -> anyhow::Result<Option<Vec<String>>> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .manifest_path(manifest_path)
+        .no_deps()
+        .exec()
+        .with_context(|| {
+            format!(
+                "failed to load cargo metadata from {}",
+                manifest_path.display()
+            )
+        })?;
+    let Some(pkg) = metadata
+        .packages
+        .iter()
+        .find(|pkg| pkg.name == package_name)
+    else {
+        bail!(
+            "package '{package_name}' not found in {}",
+            manifest_path.display()
+        );
+    };
+
+    parse_docs_rs_targets(&pkg.metadata)
+}
+
+fn parse_docs_rs_targets(metadata: &serde_json::Value) -> anyhow::Result<Option<Vec<String>>> {
+    let Some(docs) = metadata.get("docs") else {
+        return Ok(None);
+    };
+    let Some(docs_rs) = docs.get("rs") else {
+        return Ok(None);
+    };
+
+    let targets = match docs_rs.get("targets") {
+        Some(serde_json::Value::Array(values)) => {
+            let mut targets = Vec::with_capacity(values.len());
+            for value in values {
+                let target = value.as_str().ok_or_else(|| {
+                    anyhow!("package.metadata.docs.rs.targets must be an array of strings")
+                })?;
+                let target = target.trim();
+                if target.is_empty() {
+                    bail!("package.metadata.docs.rs.targets must not contain empty strings");
+                }
+                if !targets.iter().any(|existing| existing == target) {
+                    targets.push(target.to_string());
+                }
+            }
+            Some(targets)
+        }
+        Some(_) => bail!("package.metadata.docs.rs.targets must be an array of strings"),
+        None => None,
+    };
+
+    let default_target = match docs_rs.get("default-target") {
+        Some(serde_json::Value::String(value)) => {
+            let value = value.trim();
+            if value.is_empty() {
+                bail!("package.metadata.docs.rs.default-target must not be empty");
+            }
+            Some(value.to_string())
+        }
+        Some(_) => bail!("package.metadata.docs.rs.default-target must be a string"),
+        None => None,
+    };
+
+    let mut normalized = match targets {
+        Some(targets) if !targets.is_empty() => targets,
+        _ => Vec::new(),
+    };
+
+    if let Some(default_target) = default_target {
+        if let Some(index) = normalized
+            .iter()
+            .position(|target| target == &default_target)
+        {
+            let value = normalized.remove(index);
+            normalized.insert(0, value);
+        } else {
+            normalized.insert(0, default_target);
+        }
+    }
+
+    if normalized.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(normalized))
+    }
+}
+
+fn collect_rustup_targets() -> anyhow::Result<Vec<RustupTargetOption>> {
+    let output = Command::new("rustup")
+        .args(["target", "list"])
+        .output()
+        .context("failed to run `rustup target list`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`rustup target list` failed with {}:\n{}",
+            output.status,
+            stderr.trim()
+        );
+    }
+
+    let stdout = String::from_utf8(output.stdout)
+        .context("`rustup target list` output is not valid UTF-8")?;
+    Ok(parse_rustup_targets(&stdout))
+}
+
+fn parse_rustup_targets(output: &str) -> Vec<RustupTargetOption> {
+    let mut installed = Vec::new();
+    let mut available = Vec::new();
+
+    for line in output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        let installed_flag = line.ends_with(" (installed)");
+        let triple = line
+            .strip_suffix(" (installed)")
+            .unwrap_or(line)
+            .trim()
+            .to_string();
+        if triple.is_empty() {
+            continue;
+        }
+
+        let option = RustupTargetOption {
+            triple,
+            installed: installed_flag,
+        };
+        if installed_flag {
+            installed.push(option);
+        } else {
+            available.push(option);
+        }
+    }
+
+    installed.extend(available);
+    installed
+}
+
+fn build_target_options(candidates: TargetCandidateSet<'_>) -> Vec<HookOption> {
+    match candidates {
+        TargetCandidateSet::DocsRs(targets) => targets
+            .iter()
+            .cloned()
+            .map(|target| HookOption {
+                value: target.clone(),
+                label: target,
+                detail: Some("docs.rs target".into()),
+                disabled: false,
+            })
+            .collect(),
+        TargetCandidateSet::Rustup(targets) => targets
+            .iter()
+            .map(|target| HookOption {
+                value: target.triple.clone(),
+                label: target.triple.clone(),
+                detail: Some(if target.installed {
+                    "installed".into()
+                } else {
+                    "available".into()
+                }),
+                disabled: false,
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
+
+    use jkconfig::data::ElementHook;
+
+    use super::{
+        RustupTargetOption, TargetCandidateSet, build_config_hooks, build_target_options,
+        collect_package_doc_targets, parse_rustup_targets,
+    };
+
+    #[test]
+    fn collect_package_doc_targets_uses_targets_list() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = write_workspace_with_package(
+            temp.path(),
+            "kernel",
+            Some(
+                r#"[package.metadata.docs.rs]
+targets = ["riscv64gc-unknown-none-elf", "aarch64-unknown-none"]
+"#,
+            ),
+        );
+
+        let targets = collect_package_doc_targets(&manifest, "kernel")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            targets,
+            vec![
+                "riscv64gc-unknown-none-elf".to_string(),
+                "aarch64-unknown-none".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_package_doc_targets_uses_default_target_when_targets_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = write_workspace_with_package(
+            temp.path(),
+            "kernel",
+            Some(
+                r#"[package.metadata.docs.rs]
+default-target = "aarch64-unknown-none"
+"#,
+            ),
+        );
+
+        let targets = collect_package_doc_targets(&manifest, "kernel")
+            .unwrap()
+            .unwrap();
+        assert_eq!(targets, vec!["aarch64-unknown-none".to_string()]);
+    }
+
+    #[test]
+    fn collect_package_doc_targets_moves_default_target_to_front() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = write_workspace_with_package(
+            temp.path(),
+            "kernel",
+            Some(
+                r#"[package.metadata.docs.rs]
+targets = ["x86_64-unknown-none", "aarch64-unknown-none", "x86_64-unknown-none"]
+default-target = "aarch64-unknown-none"
+"#,
+            ),
+        );
+
+        let targets = collect_package_doc_targets(&manifest, "kernel")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            targets,
+            vec![
+                "aarch64-unknown-none".to_string(),
+                "x86_64-unknown-none".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_package_doc_targets_rejects_invalid_docs_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = write_workspace_with_package(
+            temp.path(),
+            "kernel",
+            Some(
+                r#"[package.metadata.docs.rs]
+targets = "aarch64-unknown-none"
+"#,
+            ),
+        );
+
+        let err = collect_package_doc_targets(&manifest, "kernel")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("targets"));
+        assert!(err.contains("array of strings"));
+    }
+
+    #[test]
+    fn collect_package_doc_targets_errors_for_missing_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = write_workspace_with_package(temp.path(), "kernel", None);
+
+        let err = collect_package_doc_targets(&manifest, "missing")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("package 'missing' not found"));
+    }
+
+    #[test]
+    fn parse_rustup_targets_prioritizes_installed_entries() {
+        let parsed = parse_rustup_targets(
+            "aarch64-unknown-none\nx86_64-unknown-none (installed)\nriscv64gc-unknown-none-elf\nthumbv7em-none-eabihf (installed)\n",
+        );
+
+        let triples: Vec<_> = parsed.iter().map(|target| target.triple.as_str()).collect();
+        let installed: Vec<_> = parsed.iter().map(|target| target.installed).collect();
+        assert_eq!(
+            triples,
+            vec![
+                "x86_64-unknown-none",
+                "thumbv7em-none-eabihf",
+                "aarch64-unknown-none",
+                "riscv64gc-unknown-none-elf"
+            ]
+        );
+        assert_eq!(installed, vec![true, true, false, false]);
+    }
+
+    #[test]
+    fn parse_rustup_targets_handles_empty_output() {
+        let parsed = parse_rustup_targets("");
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn build_target_options_marks_rustup_install_state() {
+        let options = build_target_options(TargetCandidateSet::Rustup(&[
+            RustupTargetOption {
+                triple: "x86_64-unknown-none".into(),
+                installed: true,
+            },
+            RustupTargetOption {
+                triple: "aarch64-unknown-none".into(),
+                installed: false,
+            },
+        ]));
+        assert_eq!(options[0].detail.as_deref(), Some("installed"));
+        assert_eq!(options[1].detail.as_deref(), Some("available"));
+    }
+
+    #[test]
+    fn build_config_hooks_include_system_target_hook() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"sample\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(temp.path().join("src")).unwrap();
+        fs::write(temp.path().join("src/lib.rs"), "").unwrap();
+
+        let hooks: Vec<ElementHook> = build_config_hooks(temp.path());
+        assert!(
+            hooks
+                .iter()
+                .any(|hook| hook.path.as_key() == "system.target")
+        );
+    }
+
+    fn write_workspace_with_package(root: &Path, package: &str, metadata: Option<&str>) -> PathBuf {
+        fs::write(
+            root.join("Cargo.toml"),
+            format!("[workspace]\nmembers = [\"{package}\"]\nresolver = \"3\"\n"),
+        )
+        .unwrap();
+
+        let package_dir = root.join(package);
+        fs::create_dir_all(package_dir.join("src")).unwrap();
+        let mut cargo_toml =
+            format!("[package]\nname = \"{package}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n");
+        if let Some(metadata) = metadata {
+            cargo_toml.push('\n');
+            cargo_toml.push_str(metadata);
+        }
+        fs::write(package_dir.join("Cargo.toml"), cargo_toml).unwrap();
+        fs::write(package_dir.join("src/lib.rs"), "").unwrap();
+        root.join("Cargo.toml")
+    }
+}

--- a/ostool/src/build/config_loader.rs
+++ b/ostool/src/build/config_loader.rs
@@ -1,0 +1,83 @@
+//! Build configuration loading shared by CLI and menuconfig flows.
+//!
+//! Loading records the resolved `.build.toml` path and applies the current
+//! someboot metadata injection policy after `jkconfig` materializes the config.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, bail};
+use jkconfig::data::ElementHook;
+
+use crate::build::{
+    config::{BuildConfig, BuildSystem},
+    someboot,
+};
+
+/// A loaded build configuration plus the path it was loaded from.
+#[derive(Debug, Clone)]
+pub struct LoadedBuildConfig {
+    path: PathBuf,
+    config: BuildConfig,
+}
+
+impl LoadedBuildConfig {
+    /// Returns the filesystem path used to load the build configuration.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Consumes the wrapper and returns the parsed build configuration.
+    pub fn into_config(self) -> BuildConfig {
+        self.config
+    }
+}
+
+/// Resolves an explicit build config path or the workspace default `.build.toml`.
+pub fn resolve_build_config_path(workspace_dir: &Path, explicit_path: Option<PathBuf>) -> PathBuf {
+    explicit_path.unwrap_or_else(|| workspace_dir.join(".build.toml"))
+}
+
+/// Loads a build configuration and applies build-time metadata injections.
+pub async fn load_build_config(
+    workspace_dir: &Path,
+    explicit_path: Option<PathBuf>,
+    menu: bool,
+    hooks: &[ElementHook],
+    enable_someboot_build_config: bool,
+) -> anyhow::Result<LoadedBuildConfig> {
+    let path = resolve_build_config_path(workspace_dir, explicit_path);
+
+    let Some(mut config): Option<BuildConfig> = jkconfig::run(path.clone(), menu, hooks)
+        .await
+        .with_context(|| format!("failed to load build config: {}", path.display()))?
+    else {
+        bail!("No build configuration obtained");
+    };
+
+    apply_someboot_build_config(workspace_dir, &mut config, enable_someboot_build_config)?;
+
+    Ok(LoadedBuildConfig { path, config })
+}
+
+fn apply_someboot_build_config(
+    workspace_dir: &Path,
+    config: &mut BuildConfig,
+    enable_someboot_build_config: bool,
+) -> anyhow::Result<()> {
+    if let BuildSystem::Cargo(cargo) = &mut config.system
+        && enable_someboot_build_config
+        && !cargo.disable_someboot_build_config
+    {
+        let manifest_path = workspace_dir.join("Cargo.toml");
+        let iter = someboot::detect_build_config_for_package(
+            &manifest_path,
+            &cargo.package,
+            &cargo.features,
+            &cargo.target,
+        )?
+        .into_iter();
+        cargo.args.extend(iter);
+    }
+
+    Ok(())
+}

--- a/ostool/src/build/mod.rs
+++ b/ostool/src/build/mod.rs
@@ -34,6 +34,8 @@ use crate::{
 };
 
 mod artifact_selector;
+pub(crate) mod config_hooks;
+pub(crate) mod config_loader;
 
 /// Cargo pipeline implementation for building projects.
 mod cargo_pipeline;
@@ -131,20 +133,10 @@ impl Tool {
         Ok(())
     }
 
-    /// Builds the project from the specified configuration file path.
+    /// Runs the custom build command from a build configuration.
     ///
-    /// This is the main entry point for building projects. It loads the
-    /// configuration from the specified path (or default `.build.toml`)
-    /// and executes the build.
-    ///
-    /// # Arguments
-    ///
-    /// * `config_path` - Optional path to the build configuration file.
-    ///   Defaults to `.build.toml` in the workspace directory.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the configuration cannot be loaded or the build fails.
+    /// Custom builds use the same artifact preparation path as Cargo builds so
+    /// runners consume a single ELF/BIN artifact state model.
     pub(crate) fn build_custom(&mut self, config: &Custom) -> anyhow::Result<()> {
         let process_context = self.process_context()?;
         crate::process::shell_run_cmd(&process_context, &config.build_cmd)?;
@@ -170,6 +162,7 @@ impl Tool {
         Ok(())
     }
 
+    /// Builds or imports the configured artifact and prepares the runtime outputs.
     pub(crate) async fn prepare_runtime_artifacts(
         &mut self,
         config: &config::BuildConfig,
@@ -187,7 +180,7 @@ impl Tool {
 
     async fn prepare_custom_runtime_artifacts(&mut self, config: &Custom) -> anyhow::Result<()> {
         self.build_custom(config)?;
-        self.prepare_elf_artifact(config.elf_path.clone().into(), config.to_bin)
+        self.prepare_runtime_artifacts_from_elf(config.elf_path.clone().into(), config.to_bin)
             .await
     }
 
@@ -353,15 +346,15 @@ mod tests {
             .unwrap();
 
         let expected_elf = elf_path.canonicalize().unwrap();
-        assert_eq!(tool.ctx.artifacts.elf.as_ref(), Some(&expected_elf));
-        assert!(tool.ctx.artifacts.bin.is_none());
+        assert_eq!(tool.ctx.artifacts.elf(), Some(expected_elf.as_path()));
+        assert!(tool.ctx.artifacts.bin().is_none());
         assert_eq!(
-            tool.ctx.artifacts.cargo_artifact_dir.as_ref(),
-            Some(&cargo_artifact_dir)
+            tool.ctx.artifacts.cargo_artifact_dir(),
+            Some(cargo_artifact_dir.as_path())
         );
         assert_eq!(
-            tool.ctx.artifacts.runtime_artifact_dir.as_ref(),
-            Some(&cargo_artifact_dir)
+            tool.ctx.artifacts.runtime_artifact_dir(),
+            Some(cargo_artifact_dir.as_path())
         );
         assert!(tool.ctx.arch.is_some());
     }

--- a/ostool/src/ctx.rs
+++ b/ostool/src/ctx.rs
@@ -7,20 +7,8 @@ use std::path::PathBuf;
 
 use object::Architecture;
 
+pub use crate::artifact::state::OutputArtifacts;
 use crate::build::config::BuildConfig;
-
-/// Build artifacts generated during the build process.
-#[derive(Default, Clone, Debug)]
-pub struct OutputArtifacts {
-    /// Path to the built ELF file.
-    pub elf: Option<PathBuf>,
-    /// Path to the converted binary file.
-    pub bin: Option<PathBuf>,
-    /// Cargo-reported directory containing the original ELF artifact.
-    pub cargo_artifact_dir: Option<PathBuf>,
-    /// Directory containing the runtime artifact consumed by runners.
-    pub runtime_artifact_dir: Option<PathBuf>,
-}
 
 /// The runtime context holding transient and final execution state.
 #[derive(Default, Clone, Debug)]

--- a/ostool/src/main.rs
+++ b/ostool/src/main.rs
@@ -378,17 +378,16 @@ fn apply_cargo_selector(
         return Ok(());
     }
 
-    let build::config::BuildSystem::Cargo(cargo) = &mut build_config.system else {
+    let build::config::BuildSystem::Cargo(cargo_config) = &mut build_config.system else {
         anyhow::bail!("--package/--bin can only be used with system.Cargo build configs");
     };
 
     if let Some(package) = &selector.package {
-        cargo.package = package.clone();
+        cargo_config.package = package.clone();
     }
     if let Some(bin) = &selector.bin {
-        cargo.bin = Some(bin.clone());
+        cargo_config.bin = Some(bin.clone());
     }
-
     tool.ctx_mut().build_config = Some(build_config.clone());
     Ok(())
 }
@@ -643,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_board_run_with_board_type() {
+    fn parse_board_run_defaults_to_no_overrides() {
         let cli = Cli::try_parse_from(["ostool", "board", "run"]).unwrap();
 
         match cli.command {
@@ -692,7 +691,8 @@ mod tests {
                     args.board_config.as_deref(),
                     Some(std::path::Path::new("remote.board.toml"))
                 );
-                assert!(args.cargo_selector.is_empty());
+                assert!(args.cargo_selector.package.is_none());
+                assert!(args.cargo_selector.bin.is_none());
                 assert_eq!(args.board_type.as_deref(), Some("rk3568"));
                 assert_eq!(args.server.server.as_deref(), Some("10.0.0.2"));
                 assert_eq!(args.server.port, Some(9000));

--- a/ostool/src/menuconfig.rs
+++ b/ostool/src/menuconfig.rs
@@ -15,7 +15,7 @@ use log::info;
 use tokio::fs;
 
 use crate::Tool;
-use crate::build::config::BuildConfig;
+use crate::build::{config::BuildConfig, config_hooks, config_loader};
 use crate::run::qemu::QemuConfig;
 use crate::run::uboot::UbootConfig;
 use crate::utils::PathResultExt;
@@ -60,10 +60,11 @@ impl MenuConfigHandler {
     }
 
     async fn handle_default_config(tool: &mut Tool) -> Result<()> {
-        let config_path = tool.resolve_build_config_path(None);
+        let config_path = config_loader::resolve_build_config_path(tool.workspace_dir(), None);
         tool.ctx_mut().build_config_path = Some(config_path.clone());
 
-        let config = jkconfig::run::<BuildConfig>(config_path.clone(), true, &tool.ui_hooks())
+        let hooks = config_hooks::build_config_hooks(tool.workspace_dir());
+        let config = jkconfig::run::<BuildConfig>(config_path.clone(), true, &hooks)
             .await
             .with_context(|| format!("failed to load build config: {}", config_path.display()))?;
 

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -155,12 +155,12 @@ pub struct RunQemuOptions {
 impl Tool {
     /// Returns the default QEMU runtime configuration for the current tool context.
     pub fn default_qemu_config(&self) -> QemuConfig {
-        build_default_qemu_config(self.ctx.arch)
+        build_default_qemu_config(self.runtime_arch())
     }
 
     /// Returns the default QEMU runtime configuration for a Cargo build config.
     pub fn default_qemu_config_for_cargo(&self, cargo: &Cargo) -> QemuConfig {
-        build_default_qemu_config(infer_target_arch(&cargo.target).or(self.ctx.arch))
+        build_default_qemu_config(infer_target_arch(&cargo.target).or(self.runtime_arch()))
     }
 
     pub async fn read_qemu_config_from_path_for_cargo(
@@ -180,7 +180,7 @@ impl Tool {
     ) -> anyhow::Result<QemuConfig> {
         self.sync_cargo_context(cargo);
         let package_dir = self.resolve_package_manifest_dir(&cargo.package)?;
-        let arch = infer_target_arch(&cargo.target).or(self.ctx.arch);
+        let arch = infer_target_arch(&cargo.target).or(self.runtime_arch());
         let config_path = resolve_qemu_config_path_in_dir(&package_dir, arch, None)?;
         let default_config = self.default_qemu_config_for_cargo(cargo);
         let scope = self.variable_scope()?;
@@ -195,7 +195,7 @@ impl Tool {
         self.sync_cargo_context(cargo);
         let scope = self.variable_scope()?;
         let dir = variables::expand_path_variables(dir, &scope)?;
-        let arch = infer_target_arch(&cargo.target).or(self.ctx.arch);
+        let arch = infer_target_arch(&cargo.target).or(self.runtime_arch());
         let config_path = resolve_qemu_config_path_in_dir(&dir, arch, None)?;
         let default_config = self.default_qemu_config_for_cargo(cargo);
         ensure_qemu_config_at_path(&scope, config_path, default_config).await
@@ -205,7 +205,7 @@ impl Tool {
     pub async fn ensure_qemu_config_in_dir(&mut self, dir: &Path) -> anyhow::Result<QemuConfig> {
         let scope = self.variable_scope()?;
         let dir = variables::expand_path_variables(dir, &scope)?;
-        let config_path = resolve_qemu_config_path_in_dir(&dir, self.ctx.arch, None)?;
+        let config_path = resolve_qemu_config_path_in_dir(&dir, self.runtime_arch(), None)?;
         let default_config = self.default_qemu_config();
         ensure_qemu_config_at_path(&scope, config_path, default_config).await
     }
@@ -337,10 +337,10 @@ impl QemuRunner<'_> {
         self.prepare_regex()?;
 
         if self.config.to_bin {
-            self.tool.objcopy_output_bin()?;
+            self.tool.ensure_runtime_bin()?;
         }
 
-        let detected_arch = self.tool.ctx.arch.ok_or_else(|| {
+        let detected_arch = self.tool.runtime_arch().ok_or_else(|| {
             anyhow!("Please specify `arch` in QEMU config or provide a valid ELF file.")
         })?;
         let arch = format!("{detected_arch:?}").to_lowercase();
@@ -422,12 +422,10 @@ impl QemuRunner<'_> {
             }
         }
 
-        if use_kernel_loader {
-            if let Some(bin_path) = &self.tool.ctx.artifacts.bin {
-                cmd.arg("-kernel").arg(bin_path);
-            } else if let Some(elf_path) = &self.tool.ctx.artifacts.elf {
-                cmd.arg("-kernel").arg(elf_path);
-            }
+        if use_kernel_loader
+            && let Some(kernel_path) = self.tool.runtime_artifacts().runtime_image()
+        {
+            cmd.arg("-kernel").arg(kernel_path);
         }
         cmd.stdin(Stdio::piped());
         cmd.stdout(Stdio::piped());
@@ -546,10 +544,10 @@ impl QemuRunner<'_> {
             return Ok(None);
         }
 
-        let arch =
-            self.tool.ctx.arch.as_ref().ok_or_else(|| {
-                anyhow::anyhow!("Cannot determine architecture for OVMF preparation")
-            })?;
+        let arch = self
+            .tool
+            .runtime_arch()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine architecture for OVMF preparation"))?;
         let tmp = std::env::temp_dir();
         let bios_dir = tmp.join("ostool").join("ovmf");
         fs::create_dir_all(&bios_dir)
@@ -583,15 +581,13 @@ impl QemuRunner<'_> {
     async fn prepare_uefi_esp(&self, arch: Arch) -> anyhow::Result<PathBuf> {
         let bin_path = self
             .tool
-            .ctx
-            .artifacts
-            .bin
-            .as_ref()
-            .ok_or_else(|| anyhow!("UEFI boot requires a BIN artifact"))?;
+            .runtime_artifacts()
+            .require_bin("UEFI boot requires a BIN artifact")?
+            .to_path_buf();
         let stem = bin_path
             .file_stem()
             .ok_or_else(|| anyhow!("invalid BIN path: {}", bin_path.display()))?;
-        let artifact_dir = self.uefi_artifact_dir(bin_path)?;
+        let artifact_dir = self.uefi_artifact_dir(&bin_path)?;
         let esp_dir = artifact_dir.join(format!("{}.esp", stem.to_string_lossy()));
         let boot_dir = esp_dir.join("EFI").join("BOOT");
         fs::create_dir_all(&boot_dir)
@@ -599,7 +595,7 @@ impl QemuRunner<'_> {
             .with_path("failed to create directory", &boot_dir)?;
 
         let boot_path = boot_dir.join(Self::default_uefi_boot_filename(arch));
-        fs::copy(bin_path, &boot_path).await.with_context(|| {
+        fs::copy(&bin_path, &boot_path).await.with_context(|| {
             format!(
                 "failed to copy EFI image from {} to {}",
                 bin_path.display(),
@@ -611,8 +607,8 @@ impl QemuRunner<'_> {
     }
 
     fn uefi_artifact_dir(&self, bin_path: &Path) -> anyhow::Result<PathBuf> {
-        if let Some(dir) = &self.tool.ctx.artifacts.runtime_artifact_dir {
-            return Ok(dir.clone());
+        if let Some(dir) = self.tool.runtime_artifacts().runtime_artifact_dir() {
+            return Ok(dir.to_path_buf());
         }
 
         let bin_path = bin_path
@@ -627,15 +623,13 @@ impl QemuRunner<'_> {
     async fn prepare_uefi_vars(&self, vars_template: &Path) -> anyhow::Result<PathBuf> {
         let bin_path = self
             .tool
-            .ctx
-            .artifacts
-            .bin
-            .as_ref()
-            .ok_or_else(|| anyhow!("UEFI boot requires a BIN artifact"))?;
+            .runtime_artifacts()
+            .require_bin("UEFI boot requires a BIN artifact")?
+            .to_path_buf();
         let stem = bin_path
             .file_stem()
             .ok_or_else(|| anyhow!("invalid BIN path: {}", bin_path.display()))?;
-        let artifact_dir = self.uefi_artifact_dir(bin_path)?;
+        let artifact_dir = self.uefi_artifact_dir(&bin_path)?;
         fs::create_dir_all(&artifact_dir)
             .await
             .with_path("failed to create directory", &artifact_dir)?;
@@ -681,7 +675,7 @@ pub(crate) fn resolve_qemu_config_path(
     tool: &Tool,
     explicit_path: Option<PathBuf>,
 ) -> anyhow::Result<PathBuf> {
-    resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.ctx.arch, explicit_path)
+    resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.runtime_arch(), explicit_path)
 }
 
 pub(crate) fn resolve_qemu_config_path_in_dir(
@@ -770,7 +764,10 @@ mod tests {
 
     use crate::{
         Tool, ToolConfig,
-        build::config::{BuildConfig, BuildSystem, Cargo},
+        build::{
+            config::{BuildConfig, BuildSystem, Cargo},
+            config_loader,
+        },
         run::{
             output_matcher::{ByteStreamMatcher, StreamMatchKind},
             shell_init::ShellAutoInitMatcher,
@@ -1056,7 +1053,9 @@ timeout = 0
         let tmp = TempDir::new().unwrap();
         write_single_crate_manifest(tmp.path());
         let mut tool = make_tool(tmp.path());
-        tool.ctx.artifacts.runtime_artifact_dir = Some(runtime_dir.clone());
+        tool.ctx
+            .artifacts
+            .set_runtime_artifact_dir(runtime_dir.clone());
 
         let runner = QemuRunner {
             tool: &mut tool,
@@ -1261,21 +1260,17 @@ fail_regex = []
     #[test]
     fn build_config_explicit_path_wins() {
         let tmp = TempDir::new().unwrap();
-        write_single_crate_manifest(tmp.path());
-        let tool = make_tool(tmp.path());
 
         let explicit = tmp.path().join("custom.build.toml");
-        let result = tool.resolve_build_config_path(Some(explicit.clone()));
+        let result = config_loader::resolve_build_config_path(tmp.path(), Some(explicit.clone()));
         assert_eq!(result, explicit);
     }
 
     #[test]
     fn build_config_defaults_to_workspace_root() {
         let tmp = TempDir::new().unwrap();
-        write_single_crate_manifest(tmp.path());
-        let tool = make_tool(tmp.path());
 
-        let result = tool.resolve_build_config_path(None);
+        let result = config_loader::resolve_build_config_path(tmp.path(), None);
         assert_eq!(result, tmp.path().join(".build.toml"));
     }
 }

--- a/ostool/src/run/tftp.rs
+++ b/ostool/src/run/tftp.rs
@@ -161,7 +161,7 @@ pub fn relative_tftp_filename(fitimage: &Path) -> anyhow::Result<String> {
 /// Starts a built-in TFTP server serving files from the build output directory.
 pub fn run_tftp_server(tool: &Tool) -> anyhow::Result<()> {
     let mut file_dir = tool.manifest_dir().clone();
-    if let Some(elf_path) = &tool.ctx().artifacts.elf {
+    if let Some(elf_path) = tool.runtime_artifacts().elf() {
         file_dir = elf_path
             .parent()
             .ok_or(anyhow!("{} no parent dir", elf_path.display()))?

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -902,10 +902,9 @@ impl RunnerBackend for RemoteBackend {
                 )
             })?;
         let output_dir = tool
-            .ctx()
-            .artifacts
-            .runtime_artifact_dir
-            .clone()
+            .runtime_artifacts()
+            .runtime_artifact_dir()
+            .map(PathBuf::from)
             .unwrap_or_else(std::env::temp_dir);
         fs::create_dir_all(&output_dir)
             .await
@@ -1036,7 +1035,11 @@ where
             Byte::from(kernel_data.len())
         );
 
-        let arch = match self.tool.ctx.arch.as_ref().unwrap() {
+        let arch = self
+            .tool
+            .runtime_arch()
+            .ok_or_else(|| anyhow!("Cannot determine architecture for FIT image generation"))?;
+        let arch = match arch {
             object::Architecture::Aarch64 => "arm64",
             object::Architecture::Arm => "arm",
             object::Architecture::LoongArch64 => "loongarch64",
@@ -1129,16 +1132,13 @@ where
 
     async fn _run(&mut self) -> anyhow::Result<()> {
         self.prepare_regex()?;
-        self.tool.objcopy_output_bin()?;
+        self.tool.ensure_runtime_bin()?;
 
         let kernel = self
             .tool
-            .ctx
-            .artifacts
-            .bin
-            .as_ref()
-            .ok_or(anyhow!("bin not exist"))?
-            .clone();
+            .runtime_artifacts()
+            .require_bin("bin not exist")?
+            .to_path_buf();
 
         info!("Starting U-Boot runner...");
 

--- a/ostool/src/tool.rs
+++ b/ostool/src/tool.rs
@@ -1,25 +1,20 @@
 //! Legacy tool facade for workspace configuration, build, and run workflows.
 
-use std::{
-    path::{Path, PathBuf},
-    process::Command,
-    sync::Arc,
-};
+use std::path::PathBuf;
 
-use anyhow::{Context, anyhow, bail};
+use anyhow::anyhow;
 use cargo_metadata::Metadata;
-use jkconfig::data::{
-    ElementHook, HookContext, HookFlow, HookOption, MessageLevel, MultiSelectBinding,
-    MultiSelectSpec, SingleSelectBinding, SingleSelectSpec,
-};
+use jkconfig::data::ElementHook;
+use object::Architecture;
 
 use crate::{
-    artifact::runtime::{
-        PreparedRuntimeArtifacts, RuntimeArtifactOptions, prepare_runtime_artifacts,
+    artifact::{
+        runtime::{PreparedRuntimeArtifacts, RuntimeArtifactOptions, prepare_runtime_artifacts},
+        state::OutputArtifacts,
     },
     build::{
         config::{BuildConfig, BuildSystem, Cargo},
-        someboot,
+        config_hooks, config_loader,
     },
     ctx::AppContext,
     invocation::Invocation,
@@ -121,6 +116,16 @@ impl Tool {
         &mut self.ctx
     }
 
+    /// Returns the currently prepared runtime artifacts.
+    pub(crate) fn runtime_artifacts(&self) -> &OutputArtifacts {
+        &self.ctx.artifacts
+    }
+
+    /// Returns the architecture detected from the current runtime artifact.
+    pub(crate) fn runtime_arch(&self) -> Option<Architecture> {
+        self.ctx.arch
+    }
+
     pub fn set_build_config_path(&mut self, path: Option<PathBuf>) {
         self.ctx.build_config_path = path;
     }
@@ -195,6 +200,18 @@ impl Tool {
         path: PathBuf,
         to_bin: bool,
     ) -> anyhow::Result<()> {
+        self.prepare_runtime_artifacts_from_elf(path, to_bin).await
+    }
+
+    /// Imports an ELF artifact through the shared runtime artifact preparation path.
+    ///
+    /// This crate-internal implementation backs the public compatibility wrapper
+    /// and build orchestration paths without exposing a second public API.
+    pub(crate) async fn prepare_runtime_artifacts_from_elf(
+        &mut self,
+        path: PathBuf,
+        to_bin: bool,
+    ) -> anyhow::Result<()> {
         let process_context = self.process_context()?;
         let prepared = prepare_runtime_artifacts(
             &process_context,
@@ -212,18 +229,22 @@ impl Tool {
         Ok(())
     }
 
+    /// Ensures a raw BIN artifact exists and returns its path.
+    pub(crate) fn ensure_runtime_bin(&mut self) -> anyhow::Result<PathBuf> {
+        self.objcopy_output_bin()
+    }
+
     /// Converts the ELF file to raw binary format.
-    pub(crate) fn objcopy_output_bin(&mut self) -> anyhow::Result<PathBuf> {
-        if let Some(bin) = &self.ctx.artifacts.bin {
+    fn objcopy_output_bin(&mut self) -> anyhow::Result<PathBuf> {
+        if let Some(bin) = self.ctx.artifacts.bin() {
             debug!("BIN file already exists: {:?}", bin);
-            return Ok(bin.clone());
+            return Ok(bin.to_path_buf());
         }
 
         let elf_path = self
             .ctx
             .artifacts
-            .elf
-            .as_ref()
+            .elf()
             .ok_or_else(|| anyhow!("elf not exist"))?;
         let process_context = self.process_context()?;
         let prepared = prepare_runtime_artifacts(
@@ -233,7 +254,7 @@ impl Tool {
                 to_bin: true,
                 bin_dir: self.bin_dir(),
                 debug: self.debug_enabled(),
-                cargo_artifact_dir: self.ctx.artifacts.cargo_artifact_dir.clone(),
+                cargo_artifact_dir: self.ctx.artifacts.cargo_artifact_dir().map(PathBuf::from),
                 strip_elf: false,
                 objcopy_program: PathBuf::from("rust-objcopy"),
             },
@@ -246,17 +267,12 @@ impl Tool {
         Ok(bin_path)
     }
 
+    /// Applies prepared runtime artifacts to legacy context state.
     pub(crate) fn apply_prepared_runtime_artifacts(&mut self, prepared: PreparedRuntimeArtifacts) {
-        self.ctx.artifacts.elf = Some(prepared.elf().to_path_buf());
-        self.ctx.artifacts.bin = prepared.bin().map(PathBuf::from);
-        self.ctx.artifacts.cargo_artifact_dir = prepared.cargo_artifact_dir().map(PathBuf::from);
-        self.ctx.artifacts.runtime_artifact_dir =
-            prepared.runtime_artifact_dir().map(PathBuf::from);
+        self.ctx
+            .artifacts
+            .apply_prepared_runtime_artifacts(&prepared);
         self.ctx.arch = prepared.arch();
-    }
-
-    pub(crate) fn resolve_build_config_path(&self, explicit_path: Option<PathBuf>) -> PathBuf {
-        explicit_path.unwrap_or_else(|| self.workspace_dir.join(".build.toml"))
     }
 
     /// Loads and prepares the build configuration.
@@ -265,36 +281,20 @@ impl Tool {
         config_path: Option<PathBuf>,
         menu: bool,
     ) -> anyhow::Result<BuildConfig> {
-        let config_path = self.resolve_build_config_path(config_path);
-        self.ctx.build_config_path = Some(config_path.clone());
-
         let hooks = self.ui_hooks();
-        let Some(mut c): Option<BuildConfig> = jkconfig::run(config_path.clone(), menu, &hooks)
-            .await
-            .with_context(|| format!("failed to load build config: {}", config_path.display()))?
-        else {
-            bail!("No build configuration obtained");
-        };
-
-        if let BuildSystem::Cargo(cargo) = &mut c.system
-            && self.someboot_build_config_enabled(cargo)
-        {
-            let iter = self.someboot_cargo_args(cargo)?.into_iter();
-            cargo.args.extend(iter);
-        }
-
-        self.ctx.build_config = Some(c.clone());
-        Ok(c)
-    }
-
-    fn someboot_cargo_args(&self, cargo: &Cargo) -> anyhow::Result<Vec<String>> {
-        let manifest_path = self.workspace_dir.join("Cargo.toml");
-        someboot::detect_build_config_for_package(
-            &manifest_path,
-            &cargo.package,
-            &cargo.features,
-            &cargo.target,
+        let loaded = config_loader::load_build_config(
+            &self.workspace_dir,
+            config_path,
+            menu,
+            &hooks,
+            !self.config.disable_someboot_build_config,
         )
+        .await?;
+
+        self.ctx.build_config_path = Some(loaded.path().to_path_buf());
+        let config = loaded.into_config();
+        self.ctx.build_config = Some(config.clone());
+        Ok(config)
     }
 
     fn package_root_for_variables(&self) -> anyhow::Result<PathBuf> {
@@ -329,398 +329,12 @@ impl Tool {
             self.manifest_dir.clone(),
             self.workspace_dir.clone(),
             self.variable_scope()?,
-            self.ctx.artifacts.elf.clone(),
+            self.ctx.artifacts.elf().map(PathBuf::from),
         ))
     }
 
     pub(crate) fn ui_hooks(&self) -> Vec<ElementHook> {
-        vec![
-            self.ui_hook_feature_select(),
-            self.ui_hook_package_select(),
-            self.ui_hook_target_select(),
-        ]
-    }
-
-    fn ui_hook_feature_select(&self) -> ElementHook {
-        let path = "system.features";
-        let cargo_toml = self.workspace_dir.join("Cargo.toml");
-        ElementHook {
-            path: path.into(),
-            callback: Arc::new(move |ctx: &mut HookContext<'_>, path| {
-                let package = ctx
-                    .get_string("system.package")?
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string();
-                if package.is_empty() {
-                    ctx.show_message(
-                        jkconfig::data::MessageLevel::Warning,
-                        "Select a package before editing features.",
-                    );
-                    return Ok(HookFlow::Consumed);
-                }
-
-                let feature_options = collect_feature_options(&cargo_toml, &package, None)?;
-                let options = feature_options
-                    .into_iter()
-                    .map(|feature| HookOption::new(feature.clone(), feature))
-                    .collect();
-
-                ctx.present_multi_select(MultiSelectSpec {
-                    title: format!("Features for {package}"),
-                    help: Some(
-                        "Space toggle  Enter apply. Dependency features use dep_name/feature."
-                            .into(),
-                    ),
-                    options,
-                    selected: ctx.get_strings(path.clone())?,
-                    min_selected: None,
-                    max_selected: None,
-                    binding: MultiSelectBinding::SetStringArray { path: path.clone() },
-                })?;
-
-                Ok(HookFlow::Consumed)
-            }),
-        }
-    }
-
-    fn ui_hook_package_select(&self) -> ElementHook {
-        let path = "system.package";
-        let cargo_toml = self.workspace_dir.join("Cargo.toml");
-
-        ElementHook {
-            path: path.into(),
-            callback: Arc::new(move |ctx: &mut HookContext<'_>, path| {
-                let mut items = Vec::new();
-                if let Ok(metadata) = cargo_metadata::MetadataCommand::new()
-                    .manifest_path(&cargo_toml)
-                    .no_deps()
-                    .exec()
-                {
-                    for pkg in &metadata.packages {
-                        items.push(pkg.name.to_string());
-                    }
-                }
-
-                let options = items
-                    .into_iter()
-                    .map(|item| HookOption::new(item.clone(), item))
-                    .collect();
-                ctx.present_single_select(SingleSelectSpec {
-                    title: "Select Package".into(),
-                    help: Some("Choose the Cargo package used by the build config.".into()),
-                    options,
-                    initial: ctx.get_string(path.clone())?,
-                    allow_clear: false,
-                    binding: SingleSelectBinding::SetString { path: path.clone() },
-                })?;
-                Ok(HookFlow::Consumed)
-            }),
-        }
-    }
-
-    fn ui_hook_target_select(&self) -> ElementHook {
-        let path = "system.target";
-        let cargo_toml = self.workspace_dir.join("Cargo.toml");
-
-        ElementHook {
-            path: path.into(),
-            callback: Arc::new(move |ctx: &mut HookContext<'_>, path| {
-                let package = ctx
-                    .get_string("system.package")?
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string();
-                let current_target = ctx.get_string(path.clone())?;
-
-                let mut warnings = Vec::new();
-                let (options, help) = if package.is_empty() {
-                    fallback_rustup_targets()?
-                } else {
-                    match collect_package_doc_targets(&cargo_toml, &package) {
-                        Ok(Some(doc_targets)) => (
-                            build_target_options(TargetCandidateSet::DocsRs(&doc_targets)),
-                            "Select a target declared by the selected package docs.rs metadata."
-                                .to_string(),
-                        ),
-                        Ok(None) => fallback_rustup_targets()?,
-                        Err(err) => {
-                            warnings.push(format!(
-                                "Failed to inspect docs.rs targets for package '{package}': {err}"
-                            ));
-                            fallback_rustup_targets()?
-                        }
-                    }
-                };
-
-                if options.is_empty() {
-                    bail!("No target candidates available for selection");
-                }
-
-                for warning in warnings {
-                    ctx.show_message(MessageLevel::Warning, warning);
-                }
-
-                ctx.present_single_select(SingleSelectSpec {
-                    title: "Select Target".into(),
-                    help: Some(help),
-                    options,
-                    initial: current_target,
-                    allow_clear: false,
-                    binding: SingleSelectBinding::SetString { path: path.clone() },
-                })?;
-
-                Ok(HookFlow::Consumed)
-            }),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RustupTargetOption {
-    triple: String,
-    installed: bool,
-}
-
-enum TargetCandidateSet<'a> {
-    DocsRs(&'a [String]),
-    Rustup(&'a [RustupTargetOption]),
-}
-
-fn fallback_rustup_targets() -> anyhow::Result<(Vec<HookOption>, String)> {
-    let rustup_targets = collect_rustup_targets()?;
-    if rustup_targets.is_empty() {
-        bail!("No Rust targets available from `rustup target list`");
-    }
-    Ok((
-        build_target_options(TargetCandidateSet::Rustup(&rustup_targets)),
-        "Package has no docs.rs targets; showing rustup targets.".to_string(),
-    ))
-}
-
-fn collect_feature_options(
-    manifest_path: &Path,
-    package_name: &str,
-    deps_filter: Option<&[String]>,
-) -> anyhow::Result<Vec<String>> {
-    let metadata = cargo_metadata::MetadataCommand::new()
-        .manifest_path(manifest_path)
-        .no_deps()
-        .exec()?;
-    let Some(pkg) = metadata
-        .packages
-        .iter()
-        .find(|pkg| pkg.name == package_name)
-    else {
-        bail!(
-            "package '{package_name}' not found in {}",
-            manifest_path.display()
-        );
-    };
-
-    let mut features = pkg.features.keys().cloned().collect::<Vec<_>>();
-    features.sort();
-
-    for dependency in &pkg.dependencies {
-        let include = match deps_filter {
-            Some(filter) => filter.contains(&dependency.name),
-            None => true,
-        };
-        if !include {
-            continue;
-        }
-
-        let Some(dep_pkg) = metadata
-            .packages
-            .iter()
-            .find(|candidate| candidate.name == dependency.name)
-        else {
-            continue;
-        };
-        let mut dep_features = dep_pkg.features.keys().cloned().collect::<Vec<_>>();
-        dep_features.sort();
-        features.extend(
-            dep_features
-                .into_iter()
-                .map(|feature| format!("{}/{}", dependency.name, feature)),
-        );
-    }
-
-    Ok(features)
-}
-
-fn collect_package_doc_targets(
-    manifest_path: &Path,
-    package_name: &str,
-) -> anyhow::Result<Option<Vec<String>>> {
-    let metadata = cargo_metadata::MetadataCommand::new()
-        .manifest_path(manifest_path)
-        .no_deps()
-        .exec()
-        .with_context(|| {
-            format!(
-                "failed to load cargo metadata from {}",
-                manifest_path.display()
-            )
-        })?;
-    let Some(pkg) = metadata
-        .packages
-        .iter()
-        .find(|pkg| pkg.name == package_name)
-    else {
-        bail!(
-            "package '{package_name}' not found in {}",
-            manifest_path.display()
-        );
-    };
-
-    parse_docs_rs_targets(&pkg.metadata)
-}
-
-fn parse_docs_rs_targets(metadata: &serde_json::Value) -> anyhow::Result<Option<Vec<String>>> {
-    let Some(docs) = metadata.get("docs") else {
-        return Ok(None);
-    };
-    let Some(docs_rs) = docs.get("rs") else {
-        return Ok(None);
-    };
-
-    let targets = match docs_rs.get("targets") {
-        Some(serde_json::Value::Array(values)) => {
-            let mut targets = Vec::with_capacity(values.len());
-            for value in values {
-                let target = value.as_str().ok_or_else(|| {
-                    anyhow!("package.metadata.docs.rs.targets must be an array of strings")
-                })?;
-                let target = target.trim();
-                if target.is_empty() {
-                    bail!("package.metadata.docs.rs.targets must not contain empty strings");
-                }
-                if !targets.iter().any(|existing| existing == target) {
-                    targets.push(target.to_string());
-                }
-            }
-            Some(targets)
-        }
-        Some(_) => bail!("package.metadata.docs.rs.targets must be an array of strings"),
-        None => None,
-    };
-
-    let default_target = match docs_rs.get("default-target") {
-        Some(serde_json::Value::String(value)) => {
-            let value = value.trim();
-            if value.is_empty() {
-                bail!("package.metadata.docs.rs.default-target must not be empty");
-            }
-            Some(value.to_string())
-        }
-        Some(_) => bail!("package.metadata.docs.rs.default-target must be a string"),
-        None => None,
-    };
-
-    let mut normalized = match targets {
-        Some(targets) if !targets.is_empty() => targets,
-        _ => Vec::new(),
-    };
-
-    if let Some(default_target) = default_target {
-        if let Some(index) = normalized
-            .iter()
-            .position(|target| target == &default_target)
-        {
-            let value = normalized.remove(index);
-            normalized.insert(0, value);
-        } else {
-            normalized.insert(0, default_target);
-        }
-    }
-
-    if normalized.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(normalized))
-    }
-}
-
-fn collect_rustup_targets() -> anyhow::Result<Vec<RustupTargetOption>> {
-    let output = Command::new("rustup")
-        .args(["target", "list"])
-        .output()
-        .context("failed to run `rustup target list`")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!(
-            "`rustup target list` failed with {}:\n{}",
-            output.status,
-            stderr.trim()
-        );
-    }
-
-    let stdout = String::from_utf8(output.stdout)
-        .context("`rustup target list` output is not valid UTF-8")?;
-    Ok(parse_rustup_targets(&stdout))
-}
-
-fn parse_rustup_targets(output: &str) -> Vec<RustupTargetOption> {
-    let mut installed = Vec::new();
-    let mut available = Vec::new();
-
-    for line in output
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-    {
-        let installed_flag = line.ends_with(" (installed)");
-        let triple = line
-            .strip_suffix(" (installed)")
-            .unwrap_or(line)
-            .trim()
-            .to_string();
-        if triple.is_empty() {
-            continue;
-        }
-
-        let option = RustupTargetOption {
-            triple,
-            installed: installed_flag,
-        };
-        if installed_flag {
-            installed.push(option);
-        } else {
-            available.push(option);
-        }
-    }
-
-    installed.extend(available);
-    installed
-}
-
-fn build_target_options(candidates: TargetCandidateSet<'_>) -> Vec<HookOption> {
-    match candidates {
-        TargetCandidateSet::DocsRs(targets) => targets
-            .iter()
-            .cloned()
-            .map(|target| HookOption {
-                value: target.clone(),
-                label: target,
-                detail: Some("docs.rs target".into()),
-                disabled: false,
-            })
-            .collect(),
-        TargetCandidateSet::Rustup(targets) => targets
-            .iter()
-            .map(|target| HookOption {
-                value: target.triple.clone(),
-                label: target.triple.clone(),
-                detail: Some(if target.installed {
-                    "installed".into()
-                } else {
-                    "available".into()
-                }),
-                disabled: false,
-            })
-            .collect(),
+        config_hooks::build_config_hooks(&self.workspace_dir)
     }
 }
 
@@ -730,15 +344,11 @@ pub fn resolve_manifest_context(input: Option<PathBuf>) -> anyhow::Result<Manife
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        Tool, ToolConfig, build_target_options, collect_package_doc_targets, parse_rustup_targets,
-        resolve_manifest_context,
-    };
+    use super::{Tool, ToolConfig, resolve_manifest_context};
     use crate::artifact::runtime::{RuntimeArtifactOptions, prepare_runtime_artifacts};
     use crate::build::config::{BuildConfig, BuildSystem, Cargo};
     use crate::run::qemu::resolve_qemu_config_path_in_dir;
     use crate::{process, project::variables};
-    use jkconfig::data::ElementHook;
     use object::Architecture;
     use std::{
         collections::HashMap,
@@ -785,17 +395,17 @@ mod tests {
         let expected_elf = copied.canonicalize().unwrap();
         let expected_dir = expected_elf.parent().unwrap().to_path_buf();
 
-        assert_eq!(tool.ctx.artifacts.elf.as_ref(), Some(&expected_elf));
+        assert_eq!(tool.ctx.artifacts.elf(), Some(expected_elf.as_path()));
         assert_eq!(
-            tool.ctx.artifacts.cargo_artifact_dir.as_ref(),
-            Some(&expected_dir)
+            tool.ctx.artifacts.cargo_artifact_dir(),
+            Some(expected_dir.as_path())
         );
         assert_eq!(
-            tool.ctx.artifacts.runtime_artifact_dir.as_ref(),
-            Some(&expected_dir)
+            tool.ctx.artifacts.runtime_artifact_dir(),
+            Some(expected_dir.as_path())
         );
         assert!(tool.ctx.arch.is_some());
-        assert!(tool.ctx.artifacts.bin.is_none());
+        assert!(tool.ctx.artifacts.bin().is_none());
     }
 
     #[test]
@@ -1244,194 +854,6 @@ to_bin = false
             fs::read_to_string(output).unwrap(),
             copied.canonicalize().unwrap().display().to_string()
         );
-    }
-
-    #[test]
-    fn collect_package_doc_targets_uses_targets_list() {
-        let temp = tempfile::tempdir().unwrap();
-        let manifest = write_workspace_with_package(
-            temp.path(),
-            "kernel",
-            Some(
-                r#"[package.metadata.docs.rs]
-targets = ["riscv64gc-unknown-none-elf", "aarch64-unknown-none"]
-"#,
-            ),
-        );
-
-        let targets = collect_package_doc_targets(&manifest, "kernel")
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            targets,
-            vec![
-                "riscv64gc-unknown-none-elf".to_string(),
-                "aarch64-unknown-none".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn collect_package_doc_targets_uses_default_target_when_targets_missing() {
-        let temp = tempfile::tempdir().unwrap();
-        let manifest = write_workspace_with_package(
-            temp.path(),
-            "kernel",
-            Some(
-                r#"[package.metadata.docs.rs]
-default-target = "aarch64-unknown-none"
-"#,
-            ),
-        );
-
-        let targets = collect_package_doc_targets(&manifest, "kernel")
-            .unwrap()
-            .unwrap();
-        assert_eq!(targets, vec!["aarch64-unknown-none".to_string()]);
-    }
-
-    #[test]
-    fn collect_package_doc_targets_moves_default_target_to_front() {
-        let temp = tempfile::tempdir().unwrap();
-        let manifest = write_workspace_with_package(
-            temp.path(),
-            "kernel",
-            Some(
-                r#"[package.metadata.docs.rs]
-targets = ["x86_64-unknown-none", "aarch64-unknown-none", "x86_64-unknown-none"]
-default-target = "aarch64-unknown-none"
-"#,
-            ),
-        );
-
-        let targets = collect_package_doc_targets(&manifest, "kernel")
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            targets,
-            vec![
-                "aarch64-unknown-none".to_string(),
-                "x86_64-unknown-none".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn collect_package_doc_targets_rejects_invalid_docs_metadata() {
-        let temp = tempfile::tempdir().unwrap();
-        let manifest = write_workspace_with_package(
-            temp.path(),
-            "kernel",
-            Some(
-                r#"[package.metadata.docs.rs]
-targets = "aarch64-unknown-none"
-"#,
-            ),
-        );
-
-        let err = collect_package_doc_targets(&manifest, "kernel")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("targets"));
-        assert!(err.contains("array of strings"));
-    }
-
-    #[test]
-    fn collect_package_doc_targets_errors_for_missing_package() {
-        let temp = tempfile::tempdir().unwrap();
-        let manifest = write_workspace_with_package(temp.path(), "kernel", None);
-
-        let err = collect_package_doc_targets(&manifest, "missing")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("package 'missing' not found"));
-    }
-
-    #[test]
-    fn parse_rustup_targets_prioritizes_installed_entries() {
-        let parsed = parse_rustup_targets(
-            "aarch64-unknown-none\nx86_64-unknown-none (installed)\nriscv64gc-unknown-none-elf\nthumbv7em-none-eabihf (installed)\n",
-        );
-
-        let triples: Vec<_> = parsed.iter().map(|target| target.triple.as_str()).collect();
-        let installed: Vec<_> = parsed.iter().map(|target| target.installed).collect();
-        assert_eq!(
-            triples,
-            vec![
-                "x86_64-unknown-none",
-                "thumbv7em-none-eabihf",
-                "aarch64-unknown-none",
-                "riscv64gc-unknown-none-elf"
-            ]
-        );
-        assert_eq!(installed, vec![true, true, false, false]);
-    }
-
-    #[test]
-    fn parse_rustup_targets_handles_empty_output() {
-        let parsed = parse_rustup_targets("");
-        assert!(parsed.is_empty());
-    }
-
-    #[test]
-    fn build_target_options_marks_rustup_install_state() {
-        let options = build_target_options(super::TargetCandidateSet::Rustup(&[
-            super::RustupTargetOption {
-                triple: "x86_64-unknown-none".into(),
-                installed: true,
-            },
-            super::RustupTargetOption {
-                triple: "aarch64-unknown-none".into(),
-                installed: false,
-            },
-        ]));
-        assert_eq!(options[0].detail.as_deref(), Some("installed"));
-        assert_eq!(options[1].detail.as_deref(), Some("available"));
-    }
-
-    #[test]
-    fn ui_hooks_include_system_target_hook() {
-        let temp = tempfile::tempdir().unwrap();
-        fs::write(
-            temp.path().join("Cargo.toml"),
-            "[package]\nname = \"sample\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
-        )
-        .unwrap();
-        fs::create_dir_all(temp.path().join("src")).unwrap();
-        fs::write(temp.path().join("src/lib.rs"), "").unwrap();
-
-        let tool = Tool::new(ToolConfig {
-            manifest: Some(temp.path().to_path_buf()),
-            ..Default::default()
-        })
-        .unwrap();
-
-        let hooks: Vec<ElementHook> = tool.ui_hooks();
-        assert!(
-            hooks
-                .iter()
-                .any(|hook| hook.path.as_key() == "system.target")
-        );
-    }
-
-    fn write_workspace_with_package(root: &Path, package: &str, metadata: Option<&str>) -> PathBuf {
-        fs::write(
-            root.join("Cargo.toml"),
-            format!("[workspace]\nmembers = [\"{package}\"]\nresolver = \"3\"\n"),
-        )
-        .unwrap();
-
-        let package_dir = root.join(package);
-        fs::create_dir_all(package_dir.join("src")).unwrap();
-        let mut cargo_toml =
-            format!("[package]\nname = \"{package}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n");
-        if let Some(metadata) = metadata {
-            cargo_toml.push('\n');
-            cargo_toml.push_str(metadata);
-        }
-        fs::write(package_dir.join("Cargo.toml"), cargo_toml).unwrap();
-        fs::write(package_dir.join("src/lib.rs"), "").unwrap();
-        root.join("Cargo.toml")
     }
 
     /// Writes a minimal single-package Cargo project for tool tests.


### PR DESCRIPTION
## Summary

- 将 build config loader 和 menuconfig hooks 从 legacy `Tool` facade 中拆出，减少 `tool.rs` 的业务逻辑聚集。
- 将 runtime artifact state 移到 `artifact::state::OutputArtifacts`，并通过 getter / crate-private 方法访问，避免公开可变字段继续扩散。
- 保持 QEMU/U-Boot runner 从当前 `Tool` state 读取 runtime artifact 和 architecture，不再维护第二份快照状态。
- 收窄新增 helper API，删除只锁实现细节的低信号测试和未使用的预留参数。

## Approach

这次变更保留现有 `Tool` 作为兼容 facade，但把无状态的配置加载、UI hook 构造和运行产物状态处理移到更窄的模块里。CLI、`cargo-osrun`、QEMU、U-Boot 和 board run 仍然通过已有公开入口运行，内部新增 helper 只保留 crate-private 可见性。

## Changed Modules

- `ostool/src/build/config_loader.rs`: 集中处理 build config 路径解析、加载和 someboot build config 注入。
- `ostool/src/build/config_hooks.rs`: 承载 menuconfig 的 package / feature / target hook 逻辑。
- `ostool/src/artifact/state.rs`: 承载 runtime artifact state，并收紧字段访问。
- `ostool/src/run/qemu.rs`, `ostool/src/run/uboot.rs`: runner 直接读取 `Tool` 当前运行产物状态，避免复制 artifact / arch 快照。
- `ostool/src/tool.rs`: 收缩为兼容 facade，保留现有调用入口。

## Compatibility

- CLI/config/runtime 行为保持不变。
- Public API 没有新增面；新拆出的 helper 模块保持 crate-private。
- `Tool::prepare_elf_artifact` 仍作为公开兼容入口保留。

## Verification

在 devbox 容器中运行通过：

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo test -p ostool -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo clippy --target x86_64-unknown-linux-gnu --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo build -p ostool --target x86_64-unknown-linux-gnu --all-features`
- `git diff --check`

未限制并发的 `cargo test -p ostool -- --nocapture` 曾在链接阶段因容器内存峰值报 `Cannot allocate memory`；低并发重跑已完整通过。

## Risks / Follow-up

- 本 PR 保留既有 someboot 注入顺序，不处理 selector 覆盖顺序的后续 R2 债务。
- `Tool` 仍是兼容 facade，后续切片可以继续把 runner/build orchestration 迁往更窄的输入结构。