### PR TITLE
refactor(tool): 接入 invocation 构建状态

### DIFF
--- a/ostool/src/artifact/state.rs
+++ b/ostool/src/artifact/state.rs
@@ -40,6 +40,14 @@ impl OutputArtifacts {
         self.runtime_artifact_dir.as_deref()
     }
 
+    /// Returns whether no runtime artifact has been recorded.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.elf.is_none()
+            && self.bin.is_none()
+            && self.cargo_artifact_dir.is_none()
+            && self.runtime_artifact_dir.is_none()
+    }
+
     /// Returns the preferred image path for runners that can load BIN or ELF.
     pub(crate) fn runtime_image(&self) -> Option<&Path> {
         self.bin().or_else(|| self.elf())

--- a/ostool/src/board/mod.rs
+++ b/ostool/src/board/mod.rs
@@ -185,7 +185,7 @@ impl Tool {
         cargo: &Cargo,
         path: &Path,
     ) -> anyhow::Result<BoardRunConfig> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         let scope = self.variable_scope()?;
         let path = variables::expand_path_variables(path, &scope)?;
         BoardRunConfig::read_from_path(&scope, path)
@@ -196,7 +196,7 @@ impl Tool {
         cargo: &Cargo,
         dir: &Path,
     ) -> anyhow::Result<BoardRunConfig> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         let scope = self.variable_scope()?;
         let dir = variables::expand_path_variables(dir, &scope)?;
         BoardRunConfig::load_or_create(&scope, Some(dir.join(".board.toml"))).await
@@ -236,7 +236,7 @@ impl Tool {
         board_config: &BoardRunConfig,
         options: RunBoardOptions,
     ) -> anyhow::Result<()> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         self.run_board_with_build_config(
             &BuildConfig {
                 system: BuildSystem::Cargo(cargo.clone()),

--- a/ostool/src/build/cargo_pipeline.rs
+++ b/ostool/src/build/cargo_pipeline.rs
@@ -16,7 +16,6 @@ use cargo_metadata::{Message, PackageId};
 use colored::Colorize;
 
 use crate::{
-    Tool,
     build::{
         artifact_selector::{
             CargoExecutableArtifact, ResolvedCargoArtifact, select_executable_artifact,
@@ -24,8 +23,40 @@ use crate::{
         config::{Cargo, CargoBuildProfile},
         someboot,
     },
+    process::ProcessContext,
+    project::{ProjectLayout, metadata},
     utils::{Command, PathResultExt},
 };
+
+#[derive(Debug, Clone)]
+pub(super) struct CargoBuildInput {
+    project_layout: ProjectLayout,
+    process_context: ProcessContext,
+    build_dir: PathBuf,
+    config_path: Option<PathBuf>,
+    debug: bool,
+    enable_someboot_build_config: bool,
+}
+
+impl CargoBuildInput {
+    pub(super) fn new(
+        project_layout: ProjectLayout,
+        process_context: ProcessContext,
+        build_dir: PathBuf,
+        config_path: Option<PathBuf>,
+        debug: bool,
+        enable_someboot_build_config: bool,
+    ) -> Self {
+        Self {
+            project_layout,
+            process_context,
+            build_dir,
+            config_path,
+            debug,
+            enable_someboot_build_config,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct CargoBuildOutcome {
@@ -49,7 +80,7 @@ impl CargoBuildOutcome {
 ///
 /// This builder is an internal implementation detail used by [`Tool`].
 pub struct CargoBuildPipeline<'a> {
-    tool: &'a mut Tool,
+    input: CargoBuildInput,
     config: &'a Cargo,
     cargo_program: PathBuf,
     command: String,
@@ -57,7 +88,6 @@ pub struct CargoBuildPipeline<'a> {
     extra_envs: HashMap<String, String>,
     skip_objcopy: bool,
     resolve_artifact_from_json: bool,
-    config_path: Option<PathBuf>,
 }
 
 impl<'a> CargoBuildPipeline<'a> {
@@ -65,12 +95,11 @@ impl<'a> CargoBuildPipeline<'a> {
     ///
     /// # Arguments
     ///
-    /// * `tool` - The tool context.
+    /// * `input` - Invocation-scoped Cargo build inputs.
     /// * `config` - The Cargo build configuration.
-    /// * `config_path` - Optional path to the configuration file.
-    pub fn build(tool: &'a mut Tool, config: &'a Cargo, config_path: Option<PathBuf>) -> Self {
+    pub(super) fn build(input: CargoBuildInput, config: &'a Cargo) -> Self {
         Self {
-            tool,
+            input,
             config,
             cargo_program: PathBuf::from("cargo"),
             command: "build".to_string(),
@@ -78,22 +107,7 @@ impl<'a> CargoBuildPipeline<'a> {
             extra_envs: HashMap::new(),
             skip_objcopy: false,
             resolve_artifact_from_json: true,
-            config_path,
         }
-    }
-
-    /// Sets the debug mode for the build.
-    ///
-    /// When enabled, builds in debug mode and enables GDB server for QEMU.
-    pub fn debug(self, debug: bool) -> Self {
-        self.tool.config.debug = debug;
-        self
-    }
-
-    /// Creates a build command using the context's stored config path.
-    pub fn build_auto(tool: &'a mut Tool, config: &'a Cargo) -> Self {
-        let config_path = tool.ctx.build_config_path.clone();
-        Self::build(tool, config, config_path)
     }
 
     /// Sets whether to skip the objcopy step after building.
@@ -132,9 +146,8 @@ impl<'a> CargoBuildPipeline<'a> {
     }
 
     fn run_pre_build_cmds(&mut self) -> anyhow::Result<()> {
-        let process_context = self.tool.process_context()?;
         for cmd in &self.config.pre_build_cmds {
-            crate::process::shell_run_cmd(&process_context, cmd)?;
+            crate::process::shell_run_cmd(&self.input.process_context, cmd)?;
         }
         Ok(())
     }
@@ -216,8 +229,8 @@ impl<'a> CargoBuildPipeline<'a> {
     }
 
     async fn build_cargo_command(&mut self) -> anyhow::Result<Command> {
-        let process_context = self.tool.process_context()?;
-        let mut cmd = crate::process::command(self.cargo_program.as_os_str(), &process_context);
+        let mut cmd =
+            crate::process::command(self.cargo_program.as_os_str(), &self.input.process_context);
 
         cmd.arg(&self.command);
 
@@ -249,7 +262,7 @@ impl<'a> CargoBuildPipeline<'a> {
         cmd.arg("unstable-options");
 
         cmd.arg("--target-dir");
-        cmd.arg(self.tool.build_dir().display().to_string());
+        cmd.arg(self.input.build_dir.display().to_string());
 
         // Features
         let features = self.build_features();
@@ -264,8 +277,8 @@ impl<'a> CargoBuildPipeline<'a> {
         }
 
         // Auto-detected args from someboot/build-info.toml
-        let workspace_manifest = self.tool.workspace_dir().join("Cargo.toml");
-        if self.tool.someboot_build_config_enabled(self.config) && workspace_manifest.exists() {
+        let workspace_manifest = self.input.project_layout.workspace_dir().join("Cargo.toml");
+        if self.input.enable_someboot_build_config && workspace_manifest.exists() {
             let detected_args = someboot::detect_build_config_for_package(
                 &workspace_manifest,
                 &self.config.package,
@@ -300,7 +313,7 @@ impl<'a> CargoBuildPipeline<'a> {
     }
 
     fn target_package_info(&self) -> anyhow::Result<(PackageId, Option<String>)> {
-        let metadata = self.tool.metadata()?;
+        let metadata = metadata::cargo_metadata(&self.input.project_layout)?;
         let Some(package) = metadata
             .packages
             .iter()
@@ -309,7 +322,7 @@ impl<'a> CargoBuildPipeline<'a> {
             bail!(
                 "package '{}' not found in cargo metadata under {}",
                 self.config.package,
-                self.tool.manifest_dir().display()
+                self.input.project_layout.manifest_dir().display()
             );
         };
         Ok((package.id.clone(), package.default_run.clone()))
@@ -324,19 +337,18 @@ impl<'a> CargoBuildPipeline<'a> {
     }
 
     fn effective_profile(&self) -> CargoBuildProfile {
-        self.config.profile.unwrap_or_else(|| {
-            if self.tool.debug_enabled() {
-                CargoBuildProfile::Debug
-            } else {
-                CargoBuildProfile::Release
-            }
-        })
+        let default_profile = if self.input.debug {
+            CargoBuildProfile::Debug
+        } else {
+            CargoBuildProfile::Release
+        };
+        self.config.profile.unwrap_or(default_profile)
     }
 
     fn log_level_feature(&self) -> Option<String> {
         let level = self.config.log.clone()?;
 
-        let meta = self.tool.metadata().ok()?;
+        let meta = metadata::cargo_metadata(&self.input.project_layout).ok()?;
         let pkg = meta
             .packages
             .iter()
@@ -384,7 +396,7 @@ impl<'a> CargoBuildPipeline<'a> {
             let extra = Path::new(s);
 
             if extra.is_relative() {
-                if let Some(ref config_path) = self.config_path {
+                if let Some(ref config_path) = self.input.config_path {
                     let combined = config_path
                         .parent()
                         .ok_or_else(|| {
@@ -538,12 +550,13 @@ mod tests {
             ..Default::default()
         };
 
-        let mut tool = Tool::new(ToolConfig {
+        let tool = Tool::new(ToolConfig {
             manifest: Some(temp.path().to_path_buf()),
             ..Default::default()
         })
         .unwrap();
-        let mut builder = CargoBuildPipeline::build(&mut tool, &config, None).skip_objcopy(true);
+        let input = tool.cargo_build_input(&config, false).unwrap();
+        let mut builder = CargoBuildPipeline::build(input, &config).skip_objcopy(true);
         let cmd = builder.build_cargo_command().await.unwrap();
         let args: Vec<String> = cmd
             .get_args()
@@ -580,7 +593,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut tool = Tool::new(ToolConfig {
+        let tool = Tool::new(ToolConfig {
             manifest: Some(temp.path().to_path_buf()),
             ..Default::default()
         })
@@ -612,7 +625,8 @@ mod tests {
             fs::set_permissions(&cargo_bin, permissions).unwrap();
         }
 
-        let outcome = CargoBuildPipeline::build(&mut tool, &config, None)
+        let input = tool.cargo_build_input(&config, false).unwrap();
+        let outcome = CargoBuildPipeline::build(input, &config)
             .skip_objcopy(true)
             .cargo_program(&cargo_bin)
             .execute()

--- a/ostool/src/build/mod.rs
+++ b/ostool/src/build/mod.rs
@@ -20,13 +20,17 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::bail;
+
 use crate::{
     Tool,
     artifact::runtime::{RuntimeArtifactOptions, prepare_runtime_artifacts},
     build::{
-        cargo_pipeline::{CargoBuildOutcome, CargoBuildPipeline},
-        config::{Cargo, Custom},
+        cargo_pipeline::{CargoBuildInput, CargoBuildOutcome, CargoBuildPipeline},
+        config::{BuildConfig, BuildSystem, Cargo, Custom},
     },
+    invocation::{ActiveBuildContext, ActiveCargoBuild, ActiveCustomBuild},
+    project::{ProjectLayout, metadata, variables::VariableScope},
     run::{
         qemu::{QemuConfig, RunQemuOptions},
         uboot::{RunUbootOptions, UbootConfig},
@@ -88,6 +92,77 @@ impl CargoRunnerKind {
     }
 }
 
+/// CLI overrides for Cargo package and binary target selection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CargoSelector {
+    package: Option<String>,
+    bin: Option<String>,
+}
+
+impl CargoSelector {
+    /// Creates a Cargo selector from optional CLI overrides.
+    #[cfg(test)]
+    pub(crate) fn new(package: Option<String>, bin: Option<String>) -> Self {
+        Self { package, bin }
+    }
+
+    /// Returns whether no selector override was supplied.
+    fn is_empty(&self) -> bool {
+        self.package.is_none() && self.bin.is_none()
+    }
+}
+
+/// Applies Cargo selector overrides to a build configuration.
+fn apply_cargo_selector(
+    config: &mut config::BuildConfig,
+    selector: &CargoSelector,
+) -> anyhow::Result<()> {
+    if selector.is_empty() {
+        return Ok(());
+    }
+
+    let config::BuildSystem::Cargo(cargo_config) = &mut config.system else {
+        bail!("--package/--bin can only be used with system.Cargo build configs");
+    };
+
+    if let Some(package) = &selector.package {
+        cargo_config.package = package.clone();
+    }
+    if let Some(bin) = &selector.bin {
+        cargo_config.bin = Some(bin.clone());
+    }
+    Ok(())
+}
+
+pub(crate) fn activate_build_context(
+    layout: &ProjectLayout,
+    mut config: BuildConfig,
+    config_path: Option<PathBuf>,
+    selector: &CargoSelector,
+) -> anyhow::Result<ActiveBuildContext> {
+    apply_cargo_selector(&mut config, selector)?;
+    match config.system {
+        BuildSystem::Cargo(cargo) => {
+            let package_dir = metadata::package_manifest_dir(layout, &cargo.package)?;
+            let variable_scope = VariableScope::for_package(layout, package_dir.clone());
+            Ok(ActiveBuildContext::Cargo(Box::new(ActiveCargoBuild::new(
+                cargo,
+                config_path,
+                variable_scope,
+            ))))
+        }
+        BuildSystem::Custom(custom) => {
+            let variable_scope =
+                VariableScope::for_package(layout, layout.manifest_dir().to_path_buf());
+            Ok(ActiveBuildContext::Custom(ActiveCustomBuild::new(
+                custom,
+                config_path,
+                variable_scope,
+            )))
+        }
+    }
+}
+
 impl Tool {
     /// Returns the default build configuration template.
     pub fn default_build_config(&self) -> config::BuildConfig {
@@ -124,6 +199,7 @@ impl Tool {
     ///
     /// Returns an error if the build process fails.
     pub async fn build_with_config(&mut self, config: &config::BuildConfig) -> anyhow::Result<()> {
+        self.sync_build_context(config)?;
         match &config.system {
             config::BuildSystem::Custom(custom) => self.build_custom(custom)?,
             config::BuildSystem::Cargo(cargo) => {
@@ -153,11 +229,11 @@ impl Tool {
     ///
     /// Returns an error if the Cargo build fails.
     pub async fn cargo_build(&mut self, config: &Cargo) -> anyhow::Result<()> {
-        self.sync_cargo_context(config);
-        let outcome = cargo_pipeline::CargoBuildPipeline::build_auto(self, config)
-            .execute()
-            .await?;
-        self.apply_cargo_build_outcome(config, &outcome, false)?;
+        self.sync_cargo_context(config)?;
+        let debug = self.debug_enabled();
+        let input = self.cargo_build_input(config, debug)?;
+        let outcome = CargoBuildPipeline::build(input, config).execute().await?;
+        self.apply_cargo_build_outcome(config, &outcome, false, debug)?;
         self.run_cargo_post_build_cmds(config)?;
         Ok(())
     }
@@ -168,6 +244,7 @@ impl Tool {
         config: &config::BuildConfig,
         debug: bool,
     ) -> anyhow::Result<()> {
+        self.sync_build_context(config)?;
         match &config.system {
             config::BuildSystem::Custom(custom) => {
                 self.prepare_custom_runtime_artifacts(custom).await
@@ -189,14 +266,14 @@ impl Tool {
         config: &Cargo,
         debug: bool,
     ) -> anyhow::Result<()> {
-        let build_config_path = self.ctx.build_config_path.clone();
-        let outcome = CargoBuildPipeline::build(self, config, build_config_path)
-            .debug(debug)
+        self.config.debug = debug;
+        let input = self.cargo_build_input(config, debug)?;
+        let outcome = CargoBuildPipeline::build(input, config)
             .skip_objcopy(true)
             .resolve_artifact_from_json(true)
             .execute()
             .await?;
-        self.apply_cargo_build_outcome(config, &outcome, true)?;
+        self.apply_cargo_build_outcome(config, &outcome, true, debug)?;
         self.run_cargo_post_build_cmds(config)?;
         Ok(())
     }
@@ -216,18 +293,18 @@ impl Tool {
         config: &Cargo,
         runner: &CargoRunnerKind,
     ) -> anyhow::Result<()> {
-        self.sync_cargo_context(config);
-        let build_config_path = self.ctx.build_config_path.clone();
+        self.sync_cargo_context(config)?;
 
         let debug = matches!(runner, CargoRunnerKind::Qemu(args) if args.debug);
+        self.config.debug = debug;
 
-        let outcome = CargoBuildPipeline::build(self, config, build_config_path)
-            .debug(debug)
+        let input = self.cargo_build_input(config, debug)?;
+        let outcome = CargoBuildPipeline::build(input, config)
             .skip_objcopy(true)
             .resolve_artifact_from_json(true)
             .execute()
             .await?;
-        self.apply_cargo_build_outcome(config, &outcome, true)?;
+        self.apply_cargo_build_outcome(config, &outcome, true, debug)?;
         self.run_cargo_post_build_cmds(config)?;
 
         match runner {
@@ -263,11 +340,23 @@ impl Tool {
         Ok(())
     }
 
+    fn cargo_build_input(&self, config: &Cargo, debug: bool) -> anyhow::Result<CargoBuildInput> {
+        Ok(CargoBuildInput::new(
+            self.project_layout(),
+            self.process_context()?,
+            self.build_dir(),
+            self.ctx.build_config_path.clone(),
+            debug,
+            self.someboot_build_config_enabled(config),
+        ))
+    }
+
     fn apply_cargo_build_outcome(
         &mut self,
         config: &Cargo,
         outcome: &CargoBuildOutcome,
         skip_objcopy: bool,
+        debug: bool,
     ) -> anyhow::Result<()> {
         let resolved = outcome.resolved_artifact();
         let process_context = self.process_context()?;
@@ -277,7 +366,7 @@ impl Tool {
                 elf_path: resolved.elf_path().to_path_buf(),
                 to_bin: config.to_bin && !skip_objcopy,
                 bin_dir: self.bin_dir(),
-                debug: self.debug_enabled(),
+                debug,
                 cargo_artifact_dir: Some(resolved.cargo_artifact_dir().to_path_buf()),
                 strip_elf: false,
                 objcopy_program: PathBuf::from("rust-objcopy"),
@@ -305,9 +394,12 @@ mod tests {
         build::{
             artifact_selector::ResolvedCargoArtifact,
             cargo_pipeline::CargoBuildOutcome,
-            config::{Cargo, CargoBuildProfile},
+            config::{BuildConfig, BuildSystem, Cargo, CargoBuildProfile, Custom},
         },
+        project::resolve_project_layout,
     };
+
+    use super::{CargoSelector, activate_build_context};
 
     #[test]
     fn apply_cargo_build_outcome_records_runtime_artifact_state() {
@@ -342,7 +434,7 @@ mod tests {
             cargo_artifact_dir.clone(),
         ));
 
-        tool.apply_cargo_build_outcome(&config, &outcome, true)
+        tool.apply_cargo_build_outcome(&config, &outcome, true, false)
             .unwrap();
 
         let expected_elf = elf_path.canonicalize().unwrap();
@@ -357,5 +449,75 @@ mod tests {
             Some(cargo_artifact_dir.as_path())
         );
         assert!(tool.ctx.arch.is_some());
+    }
+
+    #[test]
+    fn activate_build_context_applies_cargo_selector_and_scope() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"kernel\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(temp.path().join("src/bin")).unwrap();
+        fs::write(temp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        fs::write(temp.path().join("src/bin/kernel-qemu.rs"), "fn main() {}\n").unwrap();
+        let layout = resolve_project_layout(Some(temp.path().to_path_buf())).unwrap();
+        let config_path = temp.path().join(".build.toml");
+        let config = BuildConfig {
+            system: BuildSystem::Cargo(Cargo {
+                package: "placeholder".into(),
+                ..Default::default()
+            }),
+        };
+
+        let active = activate_build_context(
+            &layout,
+            config,
+            Some(config_path.clone()),
+            &CargoSelector::new(Some("kernel".into()), Some("kernel-qemu".into())),
+        )
+        .unwrap();
+
+        let crate::invocation::ActiveBuildContext::Cargo(active) = active else {
+            panic!("expected active Cargo build");
+        };
+        assert_eq!(active.config().package, "kernel");
+        assert_eq!(active.config().bin.as_deref(), Some("kernel-qemu"));
+        assert_eq!(active.config_path(), Some(config_path.as_path()));
+        assert_eq!(active.variable_scope().package_dir(), temp.path());
+    }
+
+    #[test]
+    fn activate_build_context_rejects_selector_for_custom_build() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"kernel\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(temp.path().join("src")).unwrap();
+        fs::write(temp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        let layout = resolve_project_layout(Some(temp.path().to_path_buf())).unwrap();
+        let config = BuildConfig {
+            system: BuildSystem::Custom(Custom {
+                build_cmd: "make".into(),
+                elf_path: "target/kernel.elf".into(),
+                to_bin: true,
+            }),
+        };
+
+        let err = activate_build_context(
+            &layout,
+            config,
+            None,
+            &CargoSelector::new(Some("kernel".into()), None),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("--package/--bin can only be used with system.Cargo")
+        );
     }
 }

--- a/ostool/src/invocation.rs
+++ b/ostool/src/invocation.rs
@@ -1,8 +1,14 @@
-//! Invocation options and project layout shared by CLI and library entrypoints.
+//! Invocation options, project layout, and runtime state shared by entrypoints.
 
 use std::path::{Path, PathBuf};
 
-use crate::project::{ProjectLayout, resolve_project_layout};
+use object::Architecture;
+
+use crate::{
+    artifact::{runtime::PreparedRuntimeArtifacts, state::OutputArtifacts},
+    build::config::{BuildConfig, BuildSystem, Cargo, Custom},
+    project::{ProjectLayout, resolve_project_layout, variables::VariableScope},
+};
 
 /// Static inputs for one CLI or library invocation.
 #[derive(Clone, Debug, Default)]
@@ -55,6 +61,7 @@ impl InvocationOptions {
 pub struct Invocation {
     options: InvocationOptions,
     project_layout: ProjectLayout,
+    state: InvocationState,
 }
 
 impl Invocation {
@@ -64,6 +71,7 @@ impl Invocation {
         Ok(Self {
             options,
             project_layout,
+            state: InvocationState::default(),
         })
     }
 
@@ -87,7 +95,255 @@ impl Invocation {
         self.project_layout.workspace_dir()
     }
 
-    pub(crate) fn into_parts(self) -> (InvocationOptions, ProjectLayout) {
-        (self.options, self.project_layout)
+    /// Returns the resolved project layout for this invocation.
+    pub fn project_layout(&self) -> &ProjectLayout {
+        &self.project_layout
+    }
+
+    pub(crate) fn into_parts(self) -> (InvocationOptions, ProjectLayout, InvocationState) {
+        (self.options, self.project_layout, self.state)
+    }
+}
+
+/// Mutable runtime state produced while one invocation is executing.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct InvocationState {
+    arch: Option<Architecture>,
+    active_build: Option<ActiveBuildContext>,
+    build_config_path: Option<PathBuf>,
+    artifacts: OutputArtifacts,
+}
+
+impl InvocationState {
+    /// Returns the detected runtime artifact architecture.
+    pub(crate) fn arch(&self) -> Option<Architecture> {
+        self.arch
+    }
+
+    /// Returns the activated build context, if a build config has been loaded.
+    pub(crate) fn active_build(&self) -> Option<&ActiveBuildContext> {
+        self.active_build.as_ref()
+    }
+
+    /// Replaces the currently active build context.
+    pub(crate) fn set_active_build(&mut self, active_build: ActiveBuildContext) {
+        self.build_config_path = active_build.config_path().map(PathBuf::from);
+        self.active_build = Some(active_build);
+    }
+
+    /// Returns the path used to load the active build configuration.
+    pub(crate) fn build_config_path(&self) -> Option<&Path> {
+        self.build_config_path.as_deref()
+    }
+
+    /// Records the path used to load the active build configuration.
+    pub(crate) fn set_build_config_path(&mut self, path: Option<PathBuf>) {
+        self.build_config_path = path;
+    }
+
+    /// Returns prepared runtime artifacts.
+    pub(crate) fn artifacts(&self) -> &OutputArtifacts {
+        &self.artifacts
+    }
+
+    /// Records prepared runtime artifacts and their detected architecture.
+    pub(crate) fn apply_prepared_runtime_artifacts(&mut self, prepared: &PreparedRuntimeArtifacts) {
+        self.artifacts.apply_prepared_runtime_artifacts(prepared);
+        self.arch = prepared.arch();
+    }
+}
+
+/// Build configuration after CLI overrides and package scope resolution.
+#[derive(Clone, Debug)]
+pub(crate) enum ActiveBuildContext {
+    /// Cargo build configuration selected for this invocation.
+    Cargo(Box<ActiveCargoBuild>),
+    /// Custom shell build configuration selected for this invocation.
+    Custom(ActiveCustomBuild),
+}
+
+impl ActiveBuildContext {
+    /// Returns the path used to load this build context.
+    pub(crate) fn config_path(&self) -> Option<&Path> {
+        match self {
+            Self::Cargo(active) => active.config_path(),
+            Self::Custom(active) => active.config_path(),
+        }
+    }
+
+    /// Returns the variable scope used for this active build.
+    pub(crate) fn variable_scope(&self) -> &VariableScope {
+        match self {
+            Self::Cargo(active) => active.variable_scope(),
+            Self::Custom(active) => active.variable_scope(),
+        }
+    }
+
+    /// Returns the activated build configuration.
+    pub(crate) fn build_config(&self) -> BuildConfig {
+        match self {
+            Self::Cargo(active) => BuildConfig {
+                system: BuildSystem::Cargo(active.config().clone()),
+            },
+            Self::Custom(active) => BuildConfig {
+                system: BuildSystem::Custom(active.config().clone()),
+            },
+        }
+    }
+}
+
+/// Activated Cargo build configuration.
+#[derive(Clone, Debug)]
+pub(crate) struct ActiveCargoBuild {
+    config: Cargo,
+    config_path: Option<PathBuf>,
+    variable_scope: VariableScope,
+}
+
+impl ActiveCargoBuild {
+    /// Creates an activated Cargo build context.
+    pub(crate) fn new(
+        config: Cargo,
+        config_path: Option<PathBuf>,
+        variable_scope: VariableScope,
+    ) -> Self {
+        Self {
+            config,
+            config_path,
+            variable_scope,
+        }
+    }
+
+    /// Returns the final Cargo config after CLI selector overrides.
+    pub(crate) fn config(&self) -> &Cargo {
+        &self.config
+    }
+
+    /// Returns the build config path, if known.
+    pub(crate) fn config_path(&self) -> Option<&Path> {
+        self.config_path.as_deref()
+    }
+
+    /// Returns the variable scope derived from the selected package.
+    pub(crate) fn variable_scope(&self) -> &VariableScope {
+        &self.variable_scope
+    }
+}
+
+/// Activated custom build configuration.
+#[derive(Clone, Debug)]
+pub(crate) struct ActiveCustomBuild {
+    config: Custom,
+    config_path: Option<PathBuf>,
+    variable_scope: VariableScope,
+}
+
+impl ActiveCustomBuild {
+    /// Creates an activated custom build context.
+    pub(crate) fn new(
+        config: Custom,
+        config_path: Option<PathBuf>,
+        variable_scope: VariableScope,
+    ) -> Self {
+        Self {
+            config,
+            config_path,
+            variable_scope,
+        }
+    }
+
+    /// Returns the final custom build config.
+    pub(crate) fn config(&self) -> &Custom {
+        &self.config
+    }
+
+    /// Returns the build config path, if known.
+    pub(crate) fn config_path(&self) -> Option<&Path> {
+        self.config_path.as_deref()
+    }
+
+    /// Returns the variable scope used by this custom build.
+    pub(crate) fn variable_scope(&self) -> &VariableScope {
+        &self.variable_scope
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use crate::{
+        build::config::{Cargo, CargoBuildProfile},
+        invocation::{ActiveBuildContext, ActiveCargoBuild, Invocation, InvocationOptions},
+        project::variables::VariableScope,
+    };
+
+    fn write_package(root: &std::path::Path) {
+        fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"kernel\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+    }
+
+    #[test]
+    fn invocation_starts_with_empty_runtime_state() {
+        let temp = tempfile::tempdir().unwrap();
+        write_package(temp.path());
+
+        let invocation = Invocation::new(InvocationOptions::new(
+            Some(temp.path().to_path_buf()),
+            None,
+            None,
+            false,
+        ))
+        .unwrap();
+
+        assert!(invocation.state.active_build().is_none());
+        assert!(invocation.state.build_config_path().is_none());
+        assert!(invocation.state.artifacts().elf().is_none());
+        assert!(invocation.state.arch().is_none());
+    }
+
+    #[test]
+    fn invocation_state_records_active_cargo_build() {
+        let temp = tempfile::tempdir().unwrap();
+        write_package(temp.path());
+        let mut invocation = Invocation::new(InvocationOptions::new(
+            Some(temp.path().to_path_buf()),
+            None,
+            None,
+            false,
+        ))
+        .unwrap();
+        let config_path = temp.path().join(".build.toml");
+        let config = Cargo {
+            target: "x86_64-unknown-none".into(),
+            package: "kernel".into(),
+            profile: Some(CargoBuildProfile::Debug),
+            ..Default::default()
+        };
+        let package_dir = invocation.manifest_dir().to_path_buf();
+        let scope = VariableScope::for_package(invocation.project_layout(), package_dir.clone());
+
+        invocation
+            .state
+            .set_active_build(ActiveBuildContext::Cargo(Box::new(ActiveCargoBuild::new(
+                config.clone(),
+                Some(config_path.clone()),
+                scope,
+            ))));
+
+        assert_eq!(
+            invocation.state.build_config_path(),
+            Some(config_path.as_path())
+        );
+        let Some(ActiveBuildContext::Cargo(active)) = invocation.state.active_build() else {
+            panic!("active Cargo build missing");
+        };
+        assert_eq!(active.config(), &config);
+        assert_eq!(active.variable_scope().package_dir(), package_dir.as_path());
     }
 }

--- a/ostool/src/legacy_context.rs
+++ b/ostool/src/legacy_context.rs
@@ -1,0 +1,72 @@
+//! Temporary compatibility bridge between `InvocationState` and legacy `AppContext`.
+//!
+//! `InvocationState` is the source of truth. `AppContext` is kept as a legacy
+//! mirror for existing `Tool::ctx`, `Tool::ctx_mut`, and `Tool::into_context`
+//! callers. Remove this module once those compatibility APIs are retired.
+
+use std::path::PathBuf;
+
+use object::Architecture;
+
+use crate::{
+    artifact::{runtime::PreparedRuntimeArtifacts, state::OutputArtifacts},
+    ctx::AppContext,
+    invocation::{ActiveBuildContext, InvocationState},
+};
+
+pub(crate) fn runtime_artifacts<'a>(
+    state: &'a InvocationState,
+    ctx: &'a AppContext,
+) -> &'a OutputArtifacts {
+    if state.artifacts().is_empty() {
+        &ctx.artifacts
+    } else {
+        state.artifacts()
+    }
+}
+
+pub(crate) fn runtime_arch(state: &InvocationState, ctx: &AppContext) -> Option<Architecture> {
+    state.arch().or(ctx.arch)
+}
+
+pub(crate) fn set_build_config_path(
+    state: &mut InvocationState,
+    ctx: &mut AppContext,
+    path: Option<PathBuf>,
+) {
+    state.set_build_config_path(path.clone());
+    ctx.build_config_path = path;
+}
+
+pub(crate) fn set_active_build(
+    state: &mut InvocationState,
+    ctx: &mut AppContext,
+    active_build: &ActiveBuildContext,
+) {
+    state.set_active_build(active_build.clone());
+    sync_build_context_from_state(ctx, state);
+}
+
+pub(crate) fn apply_prepared_runtime_artifacts(
+    state: &mut InvocationState,
+    ctx: &mut AppContext,
+    prepared: &PreparedRuntimeArtifacts,
+) {
+    state.apply_prepared_runtime_artifacts(prepared);
+    sync_runtime_context_from_state(ctx, state);
+}
+
+pub(crate) fn sync_context_from_state(ctx: &mut AppContext, state: &InvocationState) {
+    sync_build_context_from_state(ctx, state);
+    sync_runtime_context_from_state(ctx, state);
+}
+
+fn sync_build_context_from_state(ctx: &mut AppContext, state: &InvocationState) {
+    ctx.build_config_path = state.build_config_path().map(PathBuf::from);
+    ctx.build_config = state.active_build().map(ActiveBuildContext::build_config);
+}
+
+fn sync_runtime_context_from_state(ctx: &mut AppContext, state: &InvocationState) {
+    ctx.arch = state.arch();
+    ctx.artifacts = state.artifacts().clone();
+}

--- a/ostool/src/lib.rs
+++ b/ostool/src/lib.rs
@@ -46,8 +46,10 @@ pub mod board;
 /// Application context and state management.
 pub mod ctx;
 
-/// Invocation inputs and mutable runtime state.
+/// Invocation inputs and resolved project layout.
 pub mod invocation;
+
+mod legacy_context;
 
 /// Custom file logger for ostool.
 ///

--- a/ostool/src/main.rs
+++ b/ostool/src/main.rs
@@ -388,6 +388,7 @@ fn apply_cargo_selector(
     if let Some(bin) = &selector.bin {
         cargo_config.bin = Some(bin.clone());
     }
+
     tool.ctx_mut().build_config = Some(build_config.clone());
     Ok(())
 }
@@ -451,11 +452,11 @@ mod tests {
     use std::fs;
 
     use clap::Parser;
-    use ostool::{Tool, ToolConfig};
+    use ostool::{Tool, ToolConfig, resolve_manifest_context};
 
     use super::{
         BoardArgs, BoardSubCommands, CargoSelectorArgs, Cli, RunSubCommands, SubCommands,
-        apply_cargo_selector, build,
+        apply_cargo_selector, build, load_board_config,
     };
 
     /// Verifies build parsing accepts manifest, config, package, and bin overrides.
@@ -782,6 +783,72 @@ mod tests {
             err.to_string()
                 .contains("--package/--bin can only be used with system.Cargo")
         );
+    }
+
+    #[tokio::test]
+    async fn cargo_selector_updates_scope_before_board_config_load() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\", \"kernel\"]\nresolver = \"3\"\n",
+        )
+        .unwrap();
+
+        let app_dir = temp.path().join("app");
+        fs::create_dir_all(app_dir.join("src")).unwrap();
+        fs::write(
+            app_dir.join("Cargo.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        fs::write(app_dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let kernel_dir = temp.path().join("kernel");
+        fs::create_dir_all(kernel_dir.join("src/bin")).unwrap();
+        fs::write(
+            kernel_dir.join("Cargo.toml"),
+            "[package]\nname = \"kernel\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        fs::write(kernel_dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+        fs::write(kernel_dir.join("src/bin/kernel-board.rs"), "fn main() {}\n").unwrap();
+
+        fs::write(
+            temp.path().join(".board.toml"),
+            r#"
+board_type = "kernel-board"
+dtb_file = "${package}/board.dtb"
+"#,
+        )
+        .unwrap();
+
+        let mut tool = Tool::new(ToolConfig {
+            manifest: Some(app_dir.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+        let manifest = resolve_manifest_context(Some(app_dir)).unwrap();
+        let mut build_config = build::config::BuildConfig {
+            system: build::config::BuildSystem::Cargo(build::config::Cargo {
+                package: "app".into(),
+                target: "aarch64-unknown-none".into(),
+                ..Default::default()
+            }),
+        };
+
+        apply_cargo_selector(
+            &mut tool,
+            &mut build_config,
+            &CargoSelectorArgs {
+                package: Some("kernel".into()),
+                bin: Some("kernel-board".into()),
+            },
+        )
+        .unwrap();
+        let board_config = load_board_config(&mut tool, &manifest, None).await.unwrap();
+
+        let expected = kernel_dir.join("board.dtb").display().to_string();
+        assert_eq!(board_config.dtb_file.as_deref(), Some(expected.as_str()));
     }
 
     fn test_tool() -> (tempfile::TempDir, Tool) {

--- a/ostool/src/menuconfig.rs
+++ b/ostool/src/menuconfig.rs
@@ -61,7 +61,7 @@ impl MenuConfigHandler {
 
     async fn handle_default_config(tool: &mut Tool) -> Result<()> {
         let config_path = config_loader::resolve_build_config_path(tool.workspace_dir(), None);
-        tool.ctx_mut().build_config_path = Some(config_path.clone());
+        tool.set_build_config_path(Some(config_path.clone()));
 
         let hooks = config_hooks::build_config_hooks(tool.workspace_dir());
         let config = jkconfig::run::<BuildConfig>(config_path.clone(), true, &hooks)
@@ -69,12 +69,16 @@ impl MenuConfigHandler {
             .with_context(|| format!("failed to load build config: {}", config_path.display()))?;
 
         if let Some(config) = config {
-            tool.ctx_mut().build_config = Some(config);
+            Self::record_default_build_config_edit(tool, config);
         } else {
             println!("\n未更改构建配置");
         }
 
         Ok(())
+    }
+
+    fn record_default_build_config_edit(tool: &mut Tool, config: BuildConfig) {
+        tool.ctx_mut().build_config = Some(config);
     }
 
     async fn handle_qemu_config(tool: &mut Tool) -> Result<()> {
@@ -140,7 +144,13 @@ impl MenuConfigHandler {
 
 #[cfg(test)]
 mod tests {
-    use crate::build::config::BuildConfig;
+    use std::fs;
+
+    use crate::{
+        Tool, ToolConfig,
+        build::config::{BuildConfig, BuildSystem, Cargo},
+        menuconfig::MenuConfigHandler,
+    };
     use jkconfig::data::menu::MenuRoot;
     use jkconfig::data::types::ElementType;
     use schemars::schema_for;
@@ -170,5 +180,34 @@ mod tests {
             }
             other => panic!("log should be Item(Enum), got: {:?}", other),
         }
+    }
+
+    #[test]
+    fn default_config_edit_records_config_without_validating_cargo_package() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(temp.path().join("src")).unwrap();
+        fs::write(temp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let mut tool = Tool::new(ToolConfig {
+            manifest: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        })
+        .unwrap();
+        let config = BuildConfig {
+            system: BuildSystem::Cargo(Cargo {
+                package: "missing".into(),
+                target: "x86_64-unknown-none".into(),
+                ..Default::default()
+            }),
+        };
+
+        MenuConfigHandler::record_default_build_config_edit(&mut tool, config.clone());
+
+        assert_eq!(tool.ctx().build_config.as_ref(), Some(&config));
     }
 }

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -168,7 +168,7 @@ impl Tool {
         cargo: &Cargo,
         path: &Path,
     ) -> anyhow::Result<QemuConfig> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         let scope = self.variable_scope()?;
         let config_path = variables::expand_path_variables(path, &scope)?;
         read_qemu_config_at_path(&scope, config_path).await
@@ -178,7 +178,7 @@ impl Tool {
         &mut self,
         cargo: &Cargo,
     ) -> anyhow::Result<QemuConfig> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         let package_dir = self.resolve_package_manifest_dir(&cargo.package)?;
         let arch = infer_target_arch(&cargo.target).or(self.runtime_arch());
         let config_path = resolve_qemu_config_path_in_dir(&package_dir, arch, None)?;
@@ -192,7 +192,7 @@ impl Tool {
         cargo: &Cargo,
         dir: &Path,
     ) -> anyhow::Result<QemuConfig> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         let scope = self.variable_scope()?;
         let dir = variables::expand_path_variables(dir, &scope)?;
         let arch = infer_target_arch(&cargo.target).or(self.runtime_arch());

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -321,7 +321,7 @@ impl Tool {
         cargo: &crate::build::config::Cargo,
         path: &Path,
     ) -> anyhow::Result<UbootConfig> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         let scope = self.variable_scope()?;
         let config_path = variables::expand_path_variables(path, &scope)?;
         read_uboot_config_at_path(&scope, config_path).await
@@ -331,7 +331,7 @@ impl Tool {
         &mut self,
         cargo: &crate::build::config::Cargo,
     ) -> anyhow::Result<UbootConfig> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         let workspace_dir = self.workspace_dir().clone();
         self.ensure_uboot_config_in_dir_for_cargo(cargo, &workspace_dir)
             .await
@@ -342,7 +342,7 @@ impl Tool {
         cargo: &crate::build::config::Cargo,
         dir: &Path,
     ) -> anyhow::Result<UbootConfig> {
-        self.sync_cargo_context(cargo);
+        self.sync_cargo_context(cargo)?;
         let scope = self.variable_scope()?;
         let dir = variables::expand_path_variables(dir, &scope)?;
         ensure_uboot_config_at_path(&scope, dir.join(".uboot.toml"), self.default_uboot_config())

--- a/ostool/src/tool.rs
+++ b/ostool/src/tool.rs
@@ -13,11 +13,13 @@ use crate::{
         state::OutputArtifacts,
     },
     build::{
+        CargoSelector, activate_build_context,
         config::{BuildConfig, BuildSystem, Cargo},
         config_hooks, config_loader,
     },
     ctx::AppContext,
-    invocation::Invocation,
+    invocation::{ActiveBuildContext, Invocation, InvocationState},
+    legacy_context,
     process::ProcessContext,
     project::{ProjectLayout, metadata, resolve_project_layout, variables::VariableScope},
 };
@@ -44,6 +46,7 @@ pub struct Tool {
     pub(crate) manifest_path: PathBuf,
     pub(crate) manifest_dir: PathBuf,
     pub(crate) workspace_dir: PathBuf,
+    pub(crate) state: InvocationState,
     pub(crate) ctx: AppContext,
 }
 
@@ -87,7 +90,7 @@ impl Tool {
     /// Someboot build-config injection uses the same default as `Tool::new` and can
     /// be changed afterward with `set_someboot_build_config_enabled`.
     pub fn from_invocation(invocation: Invocation) -> Self {
-        let (options, layout) = invocation.into_parts();
+        let (options, layout, state) = invocation.into_parts();
         let config = ToolConfig {
             manifest: Some(layout.manifest_path().to_path_buf()),
             build_dir: options.build_dir().map(PathBuf::from),
@@ -95,7 +98,10 @@ impl Tool {
             debug: options.debug(),
             ..Default::default()
         };
-        Self::from_project_layout(config, layout)
+        let mut tool = Self::from_project_layout(config, layout);
+        tool.state = state;
+        legacy_context::sync_context_from_state(&mut tool.ctx, &tool.state);
+        tool
     }
 
     pub(crate) fn from_project_layout(config: ToolConfig, layout: ProjectLayout) -> Self {
@@ -104,6 +110,7 @@ impl Tool {
             manifest_path: layout.manifest_path().to_path_buf(),
             manifest_dir: layout.manifest_dir().to_path_buf(),
             workspace_dir: layout.workspace_dir().to_path_buf(),
+            state: InvocationState::default(),
             ctx: AppContext::default(),
         }
     }
@@ -112,22 +119,26 @@ impl Tool {
         &self.ctx
     }
 
+    /// Returns mutable legacy context for compatibility callers.
+    ///
+    /// Prefer state-aware `Tool` methods for new code. Direct mutations here do
+    /// not update `InvocationState`, which is the current source of truth.
     pub fn ctx_mut(&mut self) -> &mut AppContext {
         &mut self.ctx
     }
 
     /// Returns the currently prepared runtime artifacts.
     pub(crate) fn runtime_artifacts(&self) -> &OutputArtifacts {
-        &self.ctx.artifacts
+        legacy_context::runtime_artifacts(&self.state, &self.ctx)
     }
 
     /// Returns the architecture detected from the current runtime artifact.
     pub(crate) fn runtime_arch(&self) -> Option<Architecture> {
-        self.ctx.arch
+        legacy_context::runtime_arch(&self.state, &self.ctx)
     }
 
     pub fn set_build_config_path(&mut self, path: Option<PathBuf>) {
-        self.ctx.build_config_path = path;
+        legacy_context::set_build_config_path(&mut self.state, &mut self.ctx, path);
     }
 
     /// Enables or disables automatic Cargo argument injection from someboot build metadata.
@@ -147,10 +158,28 @@ impl Tool {
         self.config.debug
     }
 
-    pub(crate) fn sync_cargo_context(&mut self, cargo: &Cargo) {
-        self.ctx.build_config = Some(BuildConfig {
+    pub(crate) fn sync_build_context(&mut self, build_config: &BuildConfig) -> anyhow::Result<()> {
+        let active_build = activate_build_context(
+            &self.project_layout(),
+            build_config.clone(),
+            self.state
+                .build_config_path()
+                .map(PathBuf::from)
+                .or_else(|| self.ctx.build_config_path.clone()),
+            &CargoSelector::default(),
+        )?;
+        self.apply_active_build_context(&active_build);
+        Ok(())
+    }
+
+    pub(crate) fn sync_cargo_context(&mut self, cargo: &Cargo) -> anyhow::Result<()> {
+        self.sync_build_context(&BuildConfig {
             system: BuildSystem::Cargo(cargo.clone()),
-        });
+        })
+    }
+
+    pub(crate) fn apply_active_build_context(&mut self, active_build: &ActiveBuildContext) {
+        legacy_context::set_active_build(&mut self.state, &mut self.ctx, active_build);
     }
 
     pub(crate) fn manifest_dir(&self) -> &PathBuf {
@@ -236,14 +265,13 @@ impl Tool {
 
     /// Converts the ELF file to raw binary format.
     fn objcopy_output_bin(&mut self) -> anyhow::Result<PathBuf> {
-        if let Some(bin) = self.ctx.artifacts.bin() {
+        if let Some(bin) = self.runtime_artifacts().bin() {
             debug!("BIN file already exists: {:?}", bin);
             return Ok(bin.to_path_buf());
         }
 
         let elf_path = self
-            .ctx
-            .artifacts
+            .runtime_artifacts()
             .elf()
             .ok_or_else(|| anyhow!("elf not exist"))?;
         let process_context = self.process_context()?;
@@ -254,7 +282,10 @@ impl Tool {
                 to_bin: true,
                 bin_dir: self.bin_dir(),
                 debug: self.debug_enabled(),
-                cargo_artifact_dir: self.ctx.artifacts.cargo_artifact_dir().map(PathBuf::from),
+                cargo_artifact_dir: self
+                    .runtime_artifacts()
+                    .cargo_artifact_dir()
+                    .map(PathBuf::from),
                 strip_elf: false,
                 objcopy_program: PathBuf::from("rust-objcopy"),
             },
@@ -269,10 +300,7 @@ impl Tool {
 
     /// Applies prepared runtime artifacts to legacy context state.
     pub(crate) fn apply_prepared_runtime_artifacts(&mut self, prepared: PreparedRuntimeArtifacts) {
-        self.ctx
-            .artifacts
-            .apply_prepared_runtime_artifacts(&prepared);
-        self.ctx.arch = prepared.arch();
+        legacy_context::apply_prepared_runtime_artifacts(&mut self.state, &mut self.ctx, &prepared);
     }
 
     /// Loads and prepares the build configuration.
@@ -291,13 +319,17 @@ impl Tool {
         )
         .await?;
 
-        self.ctx.build_config_path = Some(loaded.path().to_path_buf());
+        self.set_build_config_path(Some(loaded.path().to_path_buf()));
         let config = loaded.into_config();
         self.ctx.build_config = Some(config.clone());
         Ok(config)
     }
 
     fn package_root_for_variables(&self) -> anyhow::Result<PathBuf> {
+        if let Some(active_build) = self.state.active_build() {
+            return Ok(active_build.variable_scope().package_dir().to_path_buf());
+        }
+
         if let Some(BuildConfig {
             system: BuildSystem::Cargo(cargo),
         }) = &self.ctx.build_config
@@ -308,7 +340,7 @@ impl Tool {
         Ok(self.manifest_dir.clone())
     }
 
-    fn project_layout(&self) -> ProjectLayout {
+    pub(crate) fn project_layout(&self) -> ProjectLayout {
         ProjectLayout::from_manifest_parts(
             self.manifest_path.clone(),
             self.manifest_dir.clone(),
@@ -317,6 +349,10 @@ impl Tool {
     }
 
     pub(crate) fn variable_scope(&self) -> anyhow::Result<VariableScope> {
+        if let Some(active_build) = self.state.active_build() {
+            return Ok(active_build.variable_scope().clone());
+        }
+
         let package_dir = self.package_root_for_variables()?;
         Ok(VariableScope::for_package(
             &self.project_layout(),
@@ -329,7 +365,7 @@ impl Tool {
             self.manifest_dir.clone(),
             self.workspace_dir.clone(),
             self.variable_scope()?,
-            self.ctx.artifacts.elf().map(PathBuf::from),
+            self.runtime_artifacts().elf().map(PathBuf::from),
         ))
     }
 
@@ -395,6 +431,8 @@ mod tests {
         let expected_elf = copied.canonicalize().unwrap();
         let expected_dir = expected_elf.parent().unwrap().to_path_buf();
 
+        assert_eq!(tool.state.artifacts().elf(), Some(expected_elf.as_path()));
+        assert_eq!(tool.state.arch(), tool.ctx.arch);
         assert_eq!(tool.ctx.artifacts.elf(), Some(expected_elf.as_path()));
         assert_eq!(
             tool.ctx.artifacts.cargo_artifact_dir(),
@@ -468,6 +506,67 @@ mod tests {
 
         let resolved = tool.resolve_package_manifest_dir("kernel").unwrap();
         assert_eq!(resolved, kernel_dir);
+    }
+
+    #[test]
+    fn sync_build_context_records_invocation_state_and_legacy_context() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\", \"kernel\"]\nresolver = \"3\"\n",
+        )
+        .unwrap();
+
+        let app_dir = temp.path().join("app");
+        std::fs::create_dir_all(app_dir.join("src")).unwrap();
+        std::fs::write(
+            app_dir.join("Cargo.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        std::fs::write(app_dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let kernel_dir = temp.path().join("kernel");
+        std::fs::create_dir_all(kernel_dir.join("src/bin")).unwrap();
+        std::fs::write(
+            kernel_dir.join("Cargo.toml"),
+            "[package]\nname = \"kernel\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        std::fs::write(kernel_dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(kernel_dir.join("src/bin/kernel-qemu.rs"), "fn main() {}\n").unwrap();
+
+        let config_path = temp.path().join(".build.toml");
+        let mut tool = Tool::new(ToolConfig {
+            manifest: Some(app_dir),
+            ..Default::default()
+        })
+        .unwrap();
+        tool.set_build_config_path(Some(config_path.clone()));
+        let build_config = BuildConfig {
+            system: BuildSystem::Cargo(Cargo {
+                package: "kernel".into(),
+                bin: Some("kernel-qemu".into()),
+                target: "aarch64-unknown-none".into(),
+                ..Default::default()
+            }),
+        };
+
+        tool.sync_build_context(&build_config).unwrap();
+
+        let Some(crate::invocation::ActiveBuildContext::Cargo(active)) = tool.state.active_build()
+        else {
+            panic!("active Cargo build missing");
+        };
+        assert_eq!(active.config().package, "kernel");
+        assert_eq!(active.config().bin.as_deref(), Some("kernel-qemu"));
+        assert_eq!(active.config_path(), Some(config_path.as_path()));
+        assert_eq!(active.variable_scope().package_dir(), kernel_dir.as_path());
+        assert_eq!(tool.ctx.build_config.as_ref(), Some(&build_config));
+        assert_eq!(
+            tool.variable_scope().unwrap().package_dir(),
+            kernel_dir.as_path()
+        );
     }
 
     #[test]

--- a/ostool/tests/public_api.rs
+++ b/ostool/tests/public_api.rs
@@ -3,6 +3,8 @@ fn public_api_matches_tool_centered_runtime_construction() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/pass_tool_configs.rs");
     t.compile_fail("tests/ui/fail_cargo_pipeline.rs");
+    t.compile_fail("tests/ui/fail_build_activation_api.rs");
+    t.compile_fail("tests/ui/fail_invocation_state.rs");
     t.compile_fail("tests/ui/fail_qemu_override.rs");
     t.compile_fail("tests/ui/fail_runner_path_field.rs");
 }

--- a/ostool/tests/ui/fail_build_activation_api.rs
+++ b/ostool/tests/ui/fail_build_activation_api.rs
@@ -1,0 +1,18 @@
+use ostool::{
+    Tool, ToolConfig,
+    build::{
+        CargoSelector, apply_cargo_selector,
+        config::{BuildConfig, BuildSystem, Cargo},
+    },
+};
+
+fn main() {
+    let mut config = BuildConfig {
+        system: BuildSystem::Cargo(Cargo::default()),
+    };
+    let selector = CargoSelector::new(Some("kernel".to_owned()), None);
+    apply_cargo_selector(&mut config, &selector).unwrap();
+
+    let mut tool = Tool::new(ToolConfig::default()).unwrap();
+    tool.activate_build_config(&mut config, &selector).unwrap();
+}

--- a/ostool/tests/ui/fail_build_activation_api.stderr
+++ b/ostool/tests/ui/fail_build_activation_api.stderr
@@ -1,0 +1,38 @@
+error[E0603]: struct `CargoSelector` is private
+ --> tests/ui/fail_build_activation_api.rs:4:9
+  |
+4 |         CargoSelector, apply_cargo_selector,
+  |         ^^^^^^^^^^^^^ private struct
+  |
+note: the struct `CargoSelector` is defined here
+ --> src/build/mod.rs
+  |
+  | pub(crate) struct CargoSelector {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0603]: function `apply_cargo_selector` is private
+ --> tests/ui/fail_build_activation_api.rs:4:24
+  |
+4 |         CargoSelector, apply_cargo_selector,
+  |                        ^^^^^^^^^^^^^^^^^^^^ private function
+  |
+note: the function `apply_cargo_selector` is defined here
+ --> src/build/mod.rs
+  |
+  | / fn apply_cargo_selector(
+  | |     config: &mut config::BuildConfig,
+  | |     selector: &CargoSelector,
+  | | ) -> anyhow::Result<()> {
+  | |_______________________^
+
+error[E0599]: no method named `activate_build_config` found for struct `Tool` in the current scope
+  --> tests/ui/fail_build_activation_api.rs:17:10
+   |
+17 |     tool.activate_build_config(&mut config, &selector).unwrap();
+   |          ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: there is a method `default_build_config` with a similar name, but with different arguments
+  --> src/build/mod.rs
+   |
+   |     pub fn default_build_config(&self) -> config::BuildConfig {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ostool/tests/ui/fail_invocation_state.rs
+++ b/ostool/tests/ui/fail_invocation_state.rs
@@ -1,0 +1,6 @@
+use ostool::invocation::{ActiveBuildContext, InvocationState};
+
+fn main() {
+    let _ = core::mem::size_of::<InvocationState>();
+    let _ = core::mem::size_of::<ActiveBuildContext>();
+}

--- a/ostool/tests/ui/fail_invocation_state.stderr
+++ b/ostool/tests/ui/fail_invocation_state.stderr
@@ -1,0 +1,23 @@
+error[E0603]: enum `ActiveBuildContext` is private
+ --> tests/ui/fail_invocation_state.rs:1:26
+  |
+1 | use ostool::invocation::{ActiveBuildContext, InvocationState};
+  |                          ^^^^^^^^^^^^^^^^^^ private enum
+  |
+note: the enum `ActiveBuildContext` is defined here
+ --> src/invocation.rs
+  |
+  | pub(crate) enum ActiveBuildContext {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0603]: struct `InvocationState` is private
+ --> tests/ui/fail_invocation_state.rs:1:46
+  |
+1 | use ostool::invocation::{ActiveBuildContext, InvocationState};
+  |                                              ^^^^^^^^^^^^^^^ private struct
+  |
+note: the struct `InvocationState` is defined here
+ --> src/invocation.rs
+  |
+  | pub(crate) struct InvocationState {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

- 将 build config 激活后的运行时状态接入 `InvocationState`，让 active build、变量作用域和 runtime artifacts 有明确的内部 source of truth。
- 保持 `InvocationState`、`ActiveBuildContext`、`ActiveCargoBuild` 和 `ActiveCustomBuild` 为 crate-private 实现细节，避免把可变运行状态扩成公共 API。
- 增加临时 `legacy_context` 胶水层，把 `InvocationState` 镜像到旧 `AppContext`，集中 `Tool::ctx*` 过渡期同步逻辑。
- 将 `CargoBuildPipeline` 从 `&mut Tool` 中解耦，改为接收显式 `CargoBuildInput`，由 orchestration 层消费 build outcome 并写回 runtime artifacts。
- 保留 `menuconfig` 的编辑语义：默认 build config 编辑完成后只记录配置，不提前校验或激活 Cargo package，避免配置修复流程被 stale/missing package 阻断。
- 将 CLI `--package/--bin` selector 处理留在二进制入口私有逻辑中，内部 selector / activation helper 不作为 public API 暴露。

## Approach

这次变更继续保留 `Tool` 作为 public compatibility facade，但把可变运行状态的源头迁移到 invocation 边界。build pipeline 只负责构造/执行 Cargo 命令并返回 build facts；build orchestration 负责消费 outcome、准备 runtime artifacts，并写回 `InvocationState`。

`InvocationState` 和 active build context 现在只在 crate 内部可见。对外仍保留 `Invocation` / `InvocationOptions` / `Tool` 这类入口，但不暴露可变状态容器本身，避免形成新的长期 public API 负担。

`legacy_context` 是临时兼容层：`InvocationState` 是 source of truth，`AppContext` 只服务现有 `Tool::ctx`、`Tool::ctx_mut` 和 `Tool::into_context` 调用。后续删除旧兼容 API 时，应优先删除这个模块。

配置加载和配置编辑不再默认 eager 激活 build state。真正需要变量作用域、Cargo package 目录或 runtime artifact 的 build/run/runner config 路径会在消费具体 build config 时同步 active build。CLI selector 则保持在 `ostool` 二进制内私有应用，并在读取 `.board.toml` 前更新 legacy context，确保 `${package}` 仍按选中 package 展开。

## Changed Modules

- `ostool/src/invocation.rs`: 增加 invocation runtime state 和 active build context，并将这些状态类型收窄为 crate-private。
- `ostool/src/legacy_context.rs`: 增加临时 `InvocationState` <-> `AppContext` 兼容桥接层。
- `ostool/src/build/mod.rs`: 增加 build context activation 和 `CargoBuildInput` 构造路径；将 selector 辅助类型保持为内部实现细节。
- `ostool/src/build/cargo_pipeline.rs`: 让 pipeline 接收显式 build input，不再持有可变 `Tool`。
- `ostool/src/tool.rs`: 将 `Tool` 收缩为状态同步和兼容 facade；加载 build config 时只记录 legacy config，实际消费时再同步 active build。
- `ostool/src/main.rs`: CLI selector 改为二进制内私有处理，并补充 board config scope 回归测试。
- `ostool/src/menuconfig.rs`: 默认 build config 编辑后只记录配置，不提前验证选中的 Cargo package。
- `ostool/tests/public_api.rs`, `ostool/tests/ui/fail_invocation_state.rs`, `ostool/tests/ui/fail_build_activation_api.rs`: 增加 public API 边界回归测试。

## Compatibility

- CLI、配置格式和 runner 调用模型保持不变。
- `Tool`、`ToolConfig`、`ManifestContext` 和 `ctx::OutputArtifacts` 继续保留为兼容 API。
- `InvocationState` / `ActiveBuildContext` / active build structs 不作为 public API 暴露。
- `CargoSelector`、selector 应用函数和 build activation helper 也不作为 public API 暴露。
- `Tool::ctx_mut()` 仍保留，但新代码应优先使用 state-aware `Tool` 方法；直接修改旧 `AppContext` 不会反向更新 `InvocationState`。
- `ostool menuconfig` 仍允许用户打开并修复默认 build config，不会因为配置中的 Cargo package 暂时不存在而在编辑后立即失败。

## Verification

已运行并通过：

- `cargo fmt --all -- --check`
- `cargo test -p ostool --test public_api --target x86_64-unknown-linux-gnu -- --nocapture`
- `cargo test -p ostool --target x86_64-unknown-linux-gnu -- --nocapture`
- `cargo clippy -p ostool --target x86_64-unknown-linux-gnu --all-features`
- `cargo build -p ostool --target x86_64-unknown-linux-gnu --all-features`
- `git diff --check`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features`
- `cargo build --target x86_64-unknown-linux-gnu --all-features`
- `cargo test --target x86_64-unknown-linux-gnu -- --nocapture`

## Risks / Follow-up

- `Tool` 仍是兼容 facade；runner/board entrypoint 的显式输入迁移可以作为后续切片继续做。
- `legacy_context` 是临时过渡层，应在 `Tool::ctx` / `ctx_mut` / `into_context` 兼容面退休后删除。
- 本 PR 保留现有 someboot build config 注入语义，不处理后续 cleanup。