### PR TITLE
refactor(tool): 拆分运行入口与 Tool facade

### DIFF
--- a/ostool/src/artifact/runtime.rs
+++ b/ostool/src/artifact/runtime.rs
@@ -1,8 +1,8 @@
 //! Runtime artifact preparation helpers.
 //!
 //! The build pipeline may produce an executable in Cargo's artifact directory
-//! or receive a custom ELF path. This module normalizes that input into the ELF
-//! and optional BIN files consumed by QEMU, U-Boot, TFTP, and board runners.
+//! or receive a custom ELF path. This module normalizes that input into a runtime
+//! ELF plus optional derived images consumed by QEMU, U-Boot, TFTP, and board runners.
 
 use std::{
     fs,

--- a/ostool/src/bin/cargo-osrun.rs
+++ b/ostool/src/bin/cargo-osrun.rs
@@ -21,13 +21,13 @@ use ostool::{
 struct RunnerArgs {
     program: PathBuf,
 
-    /// Path to the binary to run on the device
+    /// Path to the Cargo-built ELF artifact.
     elf: PathBuf,
 
     /// Test name
     test_name: Option<String>,
 
-    /// Objcopy elf to binary before running
+    /// Convert the ELF to a raw binary before running.
     #[arg(long("to-bin"))]
     to_bin: bool,
 

--- a/ostool/src/board/mod.rs
+++ b/ostool/src/board/mod.rs
@@ -18,9 +18,8 @@ use crate::board::{
     session::BoardSession,
 };
 use crate::{
-    Tool,
-    build::config::{BuildConfig, BuildSystem, Cargo},
-    project::variables,
+    project::variables::{self, VariableScope},
+    run::uboot::UbootRunInput,
 };
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -175,120 +174,57 @@ async fn finalize_session(
     }
 }
 
-impl Tool {
-    pub fn default_board_run_config(&self) -> BoardRunConfig {
-        BoardRunConfig::default()
-    }
+pub(crate) async fn read_board_run_config_from_path(
+    scope: &VariableScope,
+    path: &Path,
+) -> anyhow::Result<BoardRunConfig> {
+    let path = variables::expand_path_variables(path, scope)?;
+    BoardRunConfig::read_from_path(scope, path)
+}
 
-    pub async fn read_board_run_config_from_path_for_cargo(
-        &mut self,
-        cargo: &Cargo,
-        path: &Path,
-    ) -> anyhow::Result<BoardRunConfig> {
-        self.sync_cargo_context(cargo)?;
-        let scope = self.variable_scope()?;
-        let path = variables::expand_path_variables(path, &scope)?;
-        BoardRunConfig::read_from_path(&scope, path)
-    }
+pub(crate) async fn ensure_board_run_config_in_dir(
+    scope: &VariableScope,
+    dir: &Path,
+) -> anyhow::Result<BoardRunConfig> {
+    let dir = variables::expand_path_variables(dir, scope)?;
+    BoardRunConfig::load_or_create(scope, Some(dir.join(".board.toml"))).await
+}
 
-    pub async fn ensure_board_run_config_in_dir_for_cargo(
-        &mut self,
-        cargo: &Cargo,
-        dir: &Path,
-    ) -> anyhow::Result<BoardRunConfig> {
-        self.sync_cargo_context(cargo)?;
-        let scope = self.variable_scope()?;
-        let dir = variables::expand_path_variables(dir, &scope)?;
-        BoardRunConfig::load_or_create(&scope, Some(dir.join(".board.toml"))).await
-    }
+pub(crate) async fn run_prepared_board(
+    input: UbootRunInput,
+    board_config: &BoardRunConfig,
+    options: RunBoardOptions,
+    scope: &VariableScope,
+) -> anyhow::Result<()> {
+    let global_config = load_board_global_config_with_notice()?;
+    let mut board_config = board_config.clone();
+    board_config.apply_overrides(
+        scope,
+        options.board_type.as_deref(),
+        options.server.as_deref(),
+        options.port,
+    )?;
 
-    pub async fn ensure_board_run_config_in_dir(
-        &mut self,
-        dir: &Path,
-    ) -> anyhow::Result<BoardRunConfig> {
-        let scope = self.variable_scope()?;
-        let dir = variables::expand_path_variables(dir, &scope)?;
-        BoardRunConfig::load_or_create(&scope, Some(dir.join(".board.toml"))).await
-    }
+    let (server, port) = board_config.resolve_server(None, None, &global_config.board);
+    let (client, session) = acquire_board_session(&server, port, &board_config.board_type).await?;
+    print_allocated_board_session(&session, &board_config.board_type);
 
-    pub async fn read_board_run_config_from_path(
-        &mut self,
-        path: &Path,
-    ) -> anyhow::Result<BoardRunConfig> {
-        let scope = self.variable_scope()?;
-        let path = variables::expand_path_variables(path, &scope)?;
-        BoardRunConfig::read_from_path(&scope, path)
-    }
-
-    pub async fn run_board(
-        &mut self,
-        build_config: &BuildConfig,
-        board_config: &BoardRunConfig,
-        options: RunBoardOptions,
-    ) -> anyhow::Result<()> {
-        self.run_board_with_build_config(build_config, board_config, options)
+    let run_result = match session.info().boot_mode.as_str() {
+        "uboot" => {
+            crate::run::uboot::run_uboot_remote(
+                input,
+                &board_config,
+                client,
+                session.info().clone(),
+            )
             .await
-    }
+        }
+        other => Err(anyhow!(
+            "unsupported board boot mode `{other}`; only `uboot` is supported"
+        )),
+    };
 
-    pub async fn cargo_run_board(
-        &mut self,
-        cargo: &Cargo,
-        board_config: &BoardRunConfig,
-        options: RunBoardOptions,
-    ) -> anyhow::Result<()> {
-        self.sync_cargo_context(cargo)?;
-        self.run_board_with_build_config(
-            &BuildConfig {
-                system: BuildSystem::Cargo(cargo.clone()),
-            },
-            board_config,
-            options,
-        )
-        .await
-    }
-
-    async fn run_board_with_build_config(
-        &mut self,
-        build_config: &BuildConfig,
-        board_config: &BoardRunConfig,
-        options: RunBoardOptions,
-    ) -> anyhow::Result<()> {
-        self.prepare_runtime_artifacts(build_config, false).await?;
-        self.run_prepared_board(board_config, options).await
-    }
-
-    async fn run_prepared_board(
-        &mut self,
-        board_config: &BoardRunConfig,
-        options: RunBoardOptions,
-    ) -> anyhow::Result<()> {
-        let global_config = load_board_global_config_with_notice()?;
-        let mut board_config = board_config.clone();
-        let scope = self.variable_scope()?;
-        board_config.apply_overrides(
-            &scope,
-            options.board_type.as_deref(),
-            options.server.as_deref(),
-            options.port,
-        )?;
-
-        let (server, port) = board_config.resolve_server(None, None, &global_config.board);
-        let (client, session) =
-            acquire_board_session(&server, port, &board_config.board_type).await?;
-        print_allocated_board_session(&session, &board_config.board_type);
-
-        let run_result = match session.info().boot_mode.as_str() {
-            "uboot" => {
-                self.run_uboot_remote(&board_config, client, session.info().clone())
-                    .await
-            }
-            other => Err(anyhow!(
-                "unsupported board boot mode `{other}`; only `uboot` is supported"
-            )),
-        };
-
-        finalize_session(session, run_result).await
-    }
+    finalize_session(session, run_result).await
 }
 
 #[cfg(test)]

--- a/ostool/src/legacy_context.rs
+++ b/ostool/src/legacy_context.rs
@@ -3,6 +3,8 @@
 //! `InvocationState` is the source of truth. `AppContext` is kept as a legacy
 //! mirror for existing `Tool::ctx`, `Tool::ctx_mut`, and `Tool::into_context`
 //! callers. Remove this module once those compatibility APIs are retired.
+//! Runner and config compatibility methods stay on `Tool`; this file only
+//! bridges old and new state storage.
 
 use std::path::PathBuf;
 
@@ -14,6 +16,8 @@ use crate::{
     invocation::{ActiveBuildContext, InvocationState},
 };
 
+/// Compatibility bridge for legacy `AppContext` state.
+/// Remove this helper when callers no longer read runtime artifacts through `Tool`.
 pub(crate) fn runtime_artifacts<'a>(
     state: &'a InvocationState,
     ctx: &'a AppContext,
@@ -25,10 +29,14 @@ pub(crate) fn runtime_artifacts<'a>(
     }
 }
 
+/// Compatibility bridge for legacy `AppContext` state.
+/// Remove this helper when callers no longer read runtime architecture through `Tool`.
 pub(crate) fn runtime_arch(state: &InvocationState, ctx: &AppContext) -> Option<Architecture> {
     state.arch().or(ctx.arch)
 }
 
+/// Compatibility bridge for legacy `AppContext` state.
+/// Remove this helper when callers no longer mirror build config paths into `Tool`.
 pub(crate) fn set_build_config_path(
     state: &mut InvocationState,
     ctx: &mut AppContext,
@@ -38,6 +46,8 @@ pub(crate) fn set_build_config_path(
     ctx.build_config_path = path;
 }
 
+/// Compatibility bridge for legacy `AppContext` state.
+/// Remove this helper when callers no longer mirror active builds into `Tool`.
 pub(crate) fn set_active_build(
     state: &mut InvocationState,
     ctx: &mut AppContext,
@@ -47,6 +57,8 @@ pub(crate) fn set_active_build(
     sync_build_context_from_state(ctx, state);
 }
 
+/// Compatibility bridge for legacy `AppContext` state.
+/// Remove this helper when callers no longer mirror runtime artifacts into `Tool`.
 pub(crate) fn apply_prepared_runtime_artifacts(
     state: &mut InvocationState,
     ctx: &mut AppContext,
@@ -56,16 +68,20 @@ pub(crate) fn apply_prepared_runtime_artifacts(
     sync_runtime_context_from_state(ctx, state);
 }
 
+/// Compatibility bridge for legacy `AppContext` state.
+/// Remove this helper when callers no longer sync `Tool` contexts from invocation state.
 pub(crate) fn sync_context_from_state(ctx: &mut AppContext, state: &InvocationState) {
     sync_build_context_from_state(ctx, state);
     sync_runtime_context_from_state(ctx, state);
 }
 
+// Compatibility bridge for legacy `AppContext` state; remove it with this module.
 fn sync_build_context_from_state(ctx: &mut AppContext, state: &InvocationState) {
     ctx.build_config_path = state.build_config_path().map(PathBuf::from);
     ctx.build_config = state.active_build().map(ActiveBuildContext::build_config);
 }
 
+// Compatibility bridge for legacy `AppContext` state; remove it with this module.
 fn sync_runtime_context_from_state(ctx: &mut AppContext, state: &InvocationState) {
     ctx.arch = state.arch();
     ctx.artifacts = state.artifacts().clone();

--- a/ostool/src/menuconfig.rs
+++ b/ostool/src/menuconfig.rs
@@ -84,7 +84,11 @@ impl MenuConfigHandler {
     async fn handle_qemu_config(tool: &mut Tool) -> Result<()> {
         info!("配置 QEMU 运行参数");
 
-        let config_path = crate::run::qemu::resolve_qemu_config_path(tool, None)?;
+        let config_path = crate::run::qemu::resolve_qemu_config_path_in_dir(
+            tool.workspace_dir(),
+            tool.runtime_arch(),
+            None,
+        )?;
 
         if config_path.exists() {
             println!("\n当前 QEMU 配置文件: {}", config_path.display());

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -75,7 +75,7 @@ pub struct QemuConfig {
     pub args: Vec<String>,
     /// Whether to use UEFI boot via OVMF firmware.
     pub uefi: bool,
-    /// Whether to convert ELF to raw binary before loading.
+    /// Whether build orchestration should prepare a raw BIN before loading.
     pub to_bin: bool,
     /// Regex patterns that indicate successful execution.
     pub success_regex: Vec<String>,
@@ -220,6 +220,12 @@ pub(crate) async fn run_qemu_with_config(
     run_args: RunQemuOptions,
     config: QemuConfig,
 ) -> anyhow::Result<()> {
+    if config.to_bin {
+        input
+            .artifacts
+            .require_bin("QEMU config `to_bin = true` requires a prepared BIN artifact")?;
+    }
+
     let mut runner = QemuRunner {
         input,
         config,
@@ -721,9 +727,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        QemuConfig, QemuRunInput, QemuRunner, build_default_qemu_config,
+        QemuConfig, QemuRunInput, QemuRunner, RunQemuOptions, build_default_qemu_config,
         ensure_qemu_config_at_path, infer_target_arch, read_qemu_config_at_path,
-        resolve_qemu_config_path_in_dir, timeout_duration,
+        resolve_qemu_config_path_in_dir, run_qemu_with_config, timeout_duration,
     };
     use object::Architecture;
     use std::{
@@ -734,6 +740,7 @@ mod tests {
 
     use crate::{
         Tool, ToolConfig,
+        artifact::runtime::{RuntimeArtifactOptions, prepare_runtime_artifacts},
         build::{
             config::{BuildConfig, BuildSystem, Cargo},
             config_loader,
@@ -928,6 +935,51 @@ fail_regex = []
             .unwrap();
 
         assert_eq!(config.args, vec!["-custom"]);
+    }
+
+    #[tokio::test]
+    async fn run_qemu_with_to_bin_rejects_elf_only_artifacts() {
+        let tmp = TempDir::new().unwrap();
+        write_single_crate_manifest(tmp.path());
+        let source = std::env::current_exe().unwrap();
+        let copied = tmp.path().join("sample-elf");
+        std::fs::copy(&source, &copied).unwrap();
+
+        let mut tool = make_tool(tmp.path());
+        let prepared = prepare_runtime_artifacts(
+            &tool.process_context().unwrap(),
+            RuntimeArtifactOptions {
+                elf_path: copied,
+                to_bin: false,
+                bin_dir: None,
+                debug: false,
+                cargo_artifact_dir: None,
+                strip_elf: false,
+                objcopy_program: PathBuf::from("rust-objcopy"),
+            },
+        )
+        .unwrap();
+        tool.apply_prepared_runtime_artifacts(prepared);
+        let input = qemu_input(&tool);
+
+        assert!(input.artifacts.elf().is_some());
+        assert!(input.artifacts.bin().is_none());
+
+        let err = run_qemu_with_config(
+            input,
+            RunQemuOptions::default(),
+            QemuConfig {
+                to_bin: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("QEMU config `to_bin = true` requires a prepared BIN artifact")
+        );
     }
 
     #[test]

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -143,10 +143,26 @@ pub struct RunQemuOptions {
 
 #[derive(Clone, Debug)]
 pub(crate) struct QemuRunInput {
-    pub(crate) process_context: ProcessContext,
-    pub(crate) artifacts: OutputArtifacts,
-    pub(crate) arch: Option<Architecture>,
-    pub(crate) debug: bool,
+    process_context: ProcessContext,
+    artifacts: OutputArtifacts,
+    arch: Option<Architecture>,
+    debug: bool,
+}
+
+impl QemuRunInput {
+    pub(crate) fn new(
+        process_context: ProcessContext,
+        artifacts: OutputArtifacts,
+        arch: Option<Architecture>,
+        debug: bool,
+    ) -> Self {
+        Self {
+            process_context,
+            artifacts,
+            arch,
+            debug,
+        }
+    }
 }
 
 pub(crate) fn default_qemu_config(arch: Option<Architecture>) -> QemuConfig {
@@ -771,12 +787,12 @@ mod tests {
     }
 
     fn qemu_input(tool: &Tool) -> QemuRunInput {
-        QemuRunInput {
-            process_context: tool.process_context().unwrap(),
-            artifacts: tool.runtime_artifacts().clone(),
-            arch: tool.runtime_arch(),
-            debug: tool.debug_enabled(),
-        }
+        QemuRunInput::new(
+            tool.process_context().unwrap(),
+            tool.runtime_artifacts().clone(),
+            tool.runtime_arch(),
+            tool.debug_enabled(),
+        )
     }
 
     #[test]

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -44,9 +44,11 @@ use tokio::{
 };
 
 use crate::{
-    Tool,
+    artifact::state::OutputArtifacts,
     build::config::Cargo,
+    process::ProcessContext,
     project::variables::{self, VariableScope},
+    project::{ProjectLayout, metadata},
     run::{
         output_matcher::{ByteStreamMatcher, compile_regexes, print_match_event},
         ovmf_prebuilt::{Arch, FileType, Prebuilt, Source},
@@ -139,99 +141,96 @@ pub struct RunQemuOptions {
     pub show_output: bool,
 }
 
-/// Runs the operating system in QEMU.
-///
-/// This function configures and launches QEMU with the appropriate settings
-/// based on the detected architecture and configuration file.
-///
-/// # Arguments
-///
-/// * `tool` - The tool containing paths and build artifacts.
-/// * `args` - QEMU run arguments.
-///
-/// # Errors
-///
-/// Returns an error if QEMU fails to start or exits with an error.
-impl Tool {
-    /// Returns the default QEMU runtime configuration for the current tool context.
-    pub fn default_qemu_config(&self) -> QemuConfig {
-        build_default_qemu_config(self.runtime_arch())
-    }
-
-    /// Returns the default QEMU runtime configuration for a Cargo build config.
-    pub fn default_qemu_config_for_cargo(&self, cargo: &Cargo) -> QemuConfig {
-        build_default_qemu_config(infer_target_arch(&cargo.target).or(self.runtime_arch()))
-    }
-
-    pub async fn read_qemu_config_from_path_for_cargo(
-        &mut self,
-        cargo: &Cargo,
-        path: &Path,
-    ) -> anyhow::Result<QemuConfig> {
-        self.sync_cargo_context(cargo)?;
-        let scope = self.variable_scope()?;
-        let config_path = variables::expand_path_variables(path, &scope)?;
-        read_qemu_config_at_path(&scope, config_path).await
-    }
-
-    pub async fn ensure_qemu_config_for_cargo(
-        &mut self,
-        cargo: &Cargo,
-    ) -> anyhow::Result<QemuConfig> {
-        self.sync_cargo_context(cargo)?;
-        let package_dir = self.resolve_package_manifest_dir(&cargo.package)?;
-        let arch = infer_target_arch(&cargo.target).or(self.runtime_arch());
-        let config_path = resolve_qemu_config_path_in_dir(&package_dir, arch, None)?;
-        let default_config = self.default_qemu_config_for_cargo(cargo);
-        let scope = self.variable_scope()?;
-        ensure_qemu_config_at_path(&scope, config_path, default_config).await
-    }
-
-    pub async fn ensure_qemu_config_in_dir_for_cargo(
-        &mut self,
-        cargo: &Cargo,
-        dir: &Path,
-    ) -> anyhow::Result<QemuConfig> {
-        self.sync_cargo_context(cargo)?;
-        let scope = self.variable_scope()?;
-        let dir = variables::expand_path_variables(dir, &scope)?;
-        let arch = infer_target_arch(&cargo.target).or(self.runtime_arch());
-        let config_path = resolve_qemu_config_path_in_dir(&dir, arch, None)?;
-        let default_config = self.default_qemu_config_for_cargo(cargo);
-        ensure_qemu_config_at_path(&scope, config_path, default_config).await
-    }
-
-    /// Loads a QEMU configuration from a directory using the default filename search.
-    pub async fn ensure_qemu_config_in_dir(&mut self, dir: &Path) -> anyhow::Result<QemuConfig> {
-        let scope = self.variable_scope()?;
-        let dir = variables::expand_path_variables(dir, &scope)?;
-        let config_path = resolve_qemu_config_path_in_dir(&dir, self.runtime_arch(), None)?;
-        let default_config = self.default_qemu_config();
-        ensure_qemu_config_at_path(&scope, config_path, default_config).await
-    }
-
-    /// Reads a QEMU configuration from an explicit path without creating defaults.
-    pub async fn read_qemu_config_from_path(&mut self, path: &Path) -> anyhow::Result<QemuConfig> {
-        let scope = self.variable_scope()?;
-        let config_path = variables::expand_path_variables(path, &scope)?;
-        read_qemu_config_at_path(&scope, config_path).await
-    }
-
-    /// Runs an already prepared artifact in QEMU using a fully materialized configuration.
-    pub async fn run_qemu(
-        &mut self,
-        config: &QemuConfig,
-        options: RunQemuOptions,
-    ) -> anyhow::Result<()> {
-        let mut config = config.clone();
-        let scope = self.variable_scope()?;
-        config.replace_strings(&scope)?;
-        config.normalize("QEMU runtime config")?;
-        run_qemu_with_config(self, options, config).await
-    }
+#[derive(Clone, Debug)]
+pub(crate) struct QemuRunInput {
+    pub(crate) process_context: ProcessContext,
+    pub(crate) artifacts: OutputArtifacts,
+    pub(crate) arch: Option<Architecture>,
+    pub(crate) debug: bool,
 }
 
-async fn read_qemu_config_at_path(
+pub(crate) fn default_qemu_config(arch: Option<Architecture>) -> QemuConfig {
+    build_default_qemu_config(arch)
+}
+
+pub(crate) fn default_qemu_config_for_cargo(
+    cargo: &Cargo,
+    runtime_arch: Option<Architecture>,
+) -> QemuConfig {
+    build_default_qemu_config(infer_target_arch(&cargo.target).or(runtime_arch))
+}
+
+pub(crate) async fn read_qemu_config_from_path(
+    variables: &VariableScope,
+    path: &Path,
+) -> anyhow::Result<QemuConfig> {
+    let config_path = variables::expand_path_variables(path, variables)?;
+    read_qemu_config_at_path(variables, config_path).await
+}
+
+pub(crate) async fn ensure_qemu_config_for_cargo(
+    layout: &ProjectLayout,
+    variables: &VariableScope,
+    cargo: &Cargo,
+    runtime_arch: Option<Architecture>,
+) -> anyhow::Result<QemuConfig> {
+    let package_dir = metadata::package_manifest_dir(layout, &cargo.package)?;
+    let arch = infer_target_arch(&cargo.target).or(runtime_arch);
+    let config_path = resolve_qemu_config_path_in_dir(&package_dir, arch, None)?;
+    let default_config = default_qemu_config_for_cargo(cargo, runtime_arch);
+    ensure_qemu_config_at_path(variables, config_path, default_config).await
+}
+
+pub(crate) async fn ensure_qemu_config_in_dir_for_cargo(
+    variables: &VariableScope,
+    cargo: &Cargo,
+    dir: &Path,
+    runtime_arch: Option<Architecture>,
+) -> anyhow::Result<QemuConfig> {
+    let dir = variables::expand_path_variables(dir, variables)?;
+    let arch = infer_target_arch(&cargo.target).or(runtime_arch);
+    let config_path = resolve_qemu_config_path_in_dir(&dir, arch, None)?;
+    let default_config = default_qemu_config_for_cargo(cargo, runtime_arch);
+    ensure_qemu_config_at_path(variables, config_path, default_config).await
+}
+
+pub(crate) async fn ensure_qemu_config_in_dir(
+    variables: &VariableScope,
+    dir: &Path,
+    runtime_arch: Option<Architecture>,
+) -> anyhow::Result<QemuConfig> {
+    let dir = variables::expand_path_variables(dir, variables)?;
+    let config_path = resolve_qemu_config_path_in_dir(&dir, runtime_arch, None)?;
+    let default_config = default_qemu_config(runtime_arch);
+    ensure_qemu_config_at_path(variables, config_path, default_config).await
+}
+
+pub(crate) fn prepare_qemu_runtime_config(
+    variables: &VariableScope,
+    config: &QemuConfig,
+) -> anyhow::Result<QemuConfig> {
+    let mut config = config.clone();
+    config.replace_strings(variables)?;
+    config.normalize("QEMU runtime config")?;
+    Ok(config)
+}
+
+pub(crate) async fn run_qemu_with_config(
+    input: QemuRunInput,
+    run_args: RunQemuOptions,
+    config: QemuConfig,
+) -> anyhow::Result<()> {
+    let mut runner = QemuRunner {
+        input,
+        config,
+        dtbdump: run_args.dtb_dump,
+        success_regex: vec![],
+        fail_regex: vec![],
+    };
+    runner.run().await
+}
+
+pub(crate) async fn read_qemu_config_at_path(
     variables: &VariableScope,
     config_path: PathBuf,
 ) -> anyhow::Result<QemuConfig> {
@@ -247,7 +246,7 @@ async fn read_qemu_config_at_path(
     Ok(config)
 }
 
-async fn ensure_qemu_config_at_path(
+pub(crate) async fn ensure_qemu_config_at_path(
     variables: &VariableScope,
     config_path: PathBuf,
     default_config: QemuConfig,
@@ -309,38 +308,19 @@ pub(crate) fn infer_target_arch(target: &str) -> Option<Architecture> {
     }
 }
 
-async fn run_qemu_with_config(
-    tool: &mut Tool,
-    run_args: RunQemuOptions,
-    config: QemuConfig,
-) -> anyhow::Result<()> {
-    let mut runner = QemuRunner {
-        tool,
-        config,
-        dtbdump: run_args.dtb_dump,
-        success_regex: vec![],
-        fail_regex: vec![],
-    };
-    runner.run().await
-}
-
-struct QemuRunner<'a> {
-    tool: &'a mut Tool,
+struct QemuRunner {
+    input: QemuRunInput,
     config: QemuConfig,
     dtbdump: bool,
     success_regex: Vec<regex::Regex>,
     fail_regex: Vec<regex::Regex>,
 }
 
-impl QemuRunner<'_> {
+impl QemuRunner {
     async fn run(&mut self) -> anyhow::Result<()> {
         self.prepare_regex()?;
 
-        if self.config.to_bin {
-            self.tool.ensure_runtime_bin()?;
-        }
-
-        let detected_arch = self.tool.runtime_arch().ok_or_else(|| {
+        let detected_arch = self.input.arch.ok_or_else(|| {
             anyhow!("Please specify `arch` in QEMU config or provide a valid ELF file.")
         })?;
         let arch = format!("{detected_arch:?}").to_lowercase();
@@ -369,8 +349,7 @@ impl QemuRunner<'_> {
             }
         }
 
-        let process_context = self.tool.process_context()?;
-        let mut cmd = crate::process::command(&qemu_executable, &process_context);
+        let mut cmd = crate::process::command(&qemu_executable, &self.input.process_context);
 
         for arg in &self.config.args {
             if arg == "-machine" || arg == "-M" {
@@ -395,7 +374,7 @@ impl QemuRunner<'_> {
             cmd.arg("-machine").arg(machine);
         }
 
-        if self.tool.debug_enabled() {
+        if self.input.debug {
             cmd.arg("-s").arg("-S");
         }
 
@@ -422,9 +401,7 @@ impl QemuRunner<'_> {
             }
         }
 
-        if use_kernel_loader
-            && let Some(kernel_path) = self.tool.runtime_artifacts().runtime_image()
-        {
+        if use_kernel_loader && let Some(kernel_path) = self.input.artifacts.runtime_image() {
             cmd.arg("-kernel").arg(kernel_path);
         }
         cmd.stdin(Stdio::piped());
@@ -545,8 +522,8 @@ impl QemuRunner<'_> {
         }
 
         let arch = self
-            .tool
-            .runtime_arch()
+            .input
+            .arch
             .ok_or_else(|| anyhow::anyhow!("Cannot determine architecture for OVMF preparation"))?;
         let tmp = std::env::temp_dir();
         let bios_dir = tmp.join("ostool").join("ovmf");
@@ -580,8 +557,8 @@ impl QemuRunner<'_> {
 
     async fn prepare_uefi_esp(&self, arch: Arch) -> anyhow::Result<PathBuf> {
         let bin_path = self
-            .tool
-            .runtime_artifacts()
+            .input
+            .artifacts
             .require_bin("UEFI boot requires a BIN artifact")?
             .to_path_buf();
         let stem = bin_path
@@ -607,7 +584,7 @@ impl QemuRunner<'_> {
     }
 
     fn uefi_artifact_dir(&self, bin_path: &Path) -> anyhow::Result<PathBuf> {
-        if let Some(dir) = self.tool.runtime_artifacts().runtime_artifact_dir() {
+        if let Some(dir) = self.input.artifacts.runtime_artifact_dir() {
             return Ok(dir.to_path_buf());
         }
 
@@ -622,8 +599,8 @@ impl QemuRunner<'_> {
 
     async fn prepare_uefi_vars(&self, vars_template: &Path) -> anyhow::Result<PathBuf> {
         let bin_path = self
-            .tool
-            .runtime_artifacts()
+            .input
+            .artifacts
             .require_bin("UEFI boot requires a BIN artifact")?
             .to_path_buf();
         let stem = bin_path
@@ -671,13 +648,6 @@ impl QemuRunner<'_> {
 /// 2. workspace_dir: qemu-<arch>.toml → .qemu-<arch>.toml → qemu.toml → .qemu.toml
 ///
 /// When architecture is detected, architecture-specific files are checked first.
-pub(crate) fn resolve_qemu_config_path(
-    tool: &Tool,
-    explicit_path: Option<PathBuf>,
-) -> anyhow::Result<PathBuf> {
-    resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.runtime_arch(), explicit_path)
-}
-
 pub(crate) fn resolve_qemu_config_path_in_dir(
     search_dir: &Path,
     arch: Option<Architecture>,
@@ -751,8 +721,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        QemuConfig, QemuRunner, build_default_qemu_config, ensure_qemu_config_at_path,
-        infer_target_arch, read_qemu_config_at_path, resolve_qemu_config_path,
+        QemuConfig, QemuRunInput, QemuRunner, build_default_qemu_config,
+        ensure_qemu_config_at_path, infer_target_arch, read_qemu_config_at_path,
         resolve_qemu_config_path_in_dir, timeout_duration,
     };
     use object::Architecture;
@@ -791,6 +761,15 @@ mod tests {
             ..Default::default()
         })
         .unwrap()
+    }
+
+    fn qemu_input(tool: &Tool) -> QemuRunInput {
+        QemuRunInput {
+            process_context: tool.process_context().unwrap(),
+            artifacts: tool.runtime_artifacts().clone(),
+            arch: tool.runtime_arch(),
+            debug: tool.debug_enabled(),
+        }
     }
 
     #[test]
@@ -1056,9 +1035,10 @@ timeout = 0
         tool.ctx
             .artifacts
             .set_runtime_artifact_dir(runtime_dir.clone());
+        let input = qemu_input(&tool);
 
         let runner = QemuRunner {
-            tool: &mut tool,
+            input,
             config: QemuConfig::default(),
             dtbdump: false,
             success_regex: vec![],
@@ -1080,7 +1060,12 @@ timeout = 0
         let tool = make_tool(tmp.path());
 
         let explicit = tmp.path().join("custom.qemu.toml");
-        let result = resolve_qemu_config_path(&tool, Some(explicit.clone())).unwrap();
+        let result = resolve_qemu_config_path_in_dir(
+            tool.workspace_dir(),
+            tool.runtime_arch(),
+            Some(explicit.clone()),
+        )
+        .unwrap();
         assert_eq!(result, explicit);
     }
 
@@ -1093,7 +1078,9 @@ timeout = 0
         let mut tool = make_tool(tmp.path());
         tool.ctx.arch = Some(Architecture::Aarch64);
 
-        let result = resolve_qemu_config_path(&tool, None).unwrap();
+        let result =
+            resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.runtime_arch(), None)
+                .unwrap();
         assert_eq!(result, tmp.path().join("qemu-aarch64.toml"));
     }
 
@@ -1106,11 +1093,15 @@ timeout = 0
         tool.ctx.arch = Some(Architecture::Aarch64);
 
         std::fs::write(manifest.join("qemu.toml"), "").unwrap();
-        let result = resolve_qemu_config_path(&tool, None).unwrap();
+        let result =
+            resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.runtime_arch(), None)
+                .unwrap();
         assert_eq!(result, manifest.join("qemu.toml"));
 
         std::fs::write(manifest.join("qemu-aarch64.toml"), "").unwrap();
-        let result = resolve_qemu_config_path(&tool, None).unwrap();
+        let result =
+            resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.runtime_arch(), None)
+                .unwrap();
         assert_eq!(result, manifest.join("qemu-aarch64.toml"));
     }
 
@@ -1192,7 +1183,9 @@ fail_regex = []
         write_single_crate_manifest(tmp.path());
         let tool = make_tool(tmp.path());
 
-        let result = resolve_qemu_config_path(&tool, None).unwrap();
+        let result =
+            resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.runtime_arch(), None)
+                .unwrap();
         assert_eq!(result, tmp.path().join(".qemu.toml"));
     }
 
@@ -1203,7 +1196,9 @@ fail_regex = []
         let mut tool = make_tool(tmp.path());
         tool.ctx.arch = Some(Architecture::Aarch64);
 
-        let result = resolve_qemu_config_path(&tool, None).unwrap();
+        let result =
+            resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.runtime_arch(), None)
+                .unwrap();
         assert_eq!(result, tmp.path().join(".qemu-aarch64.toml"));
     }
 
@@ -1215,7 +1210,9 @@ fail_regex = []
         std::fs::write(tmp.path().join("qemu.toml"), "").unwrap();
 
         let tool = make_tool(tmp.path());
-        let result = resolve_qemu_config_path(&tool, None).unwrap();
+        let result =
+            resolve_qemu_config_path_in_dir(tool.workspace_dir(), tool.runtime_arch(), None)
+                .unwrap();
         assert_eq!(result, tmp.path().join("qemu.toml"));
     }
 

--- a/ostool/src/run/tftp.rs
+++ b/ostool/src/run/tftp.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, anyhow, bail};
 use colored::Colorize as _;
 use tftpd::{Config, Server};
 
-use crate::{Tool, utils::PathResultExt};
+use crate::{artifact::state::OutputArtifacts, utils::PathResultExt};
 
 const TFTP_HPA_CONFIG_PATH: &str = "/etc/default/tftpd-hpa";
 const DEFAULT_TFTP_DIRECTORY: &str = "/srv/tftp";
@@ -159,9 +159,9 @@ pub fn relative_tftp_filename(fitimage: &Path) -> anyhow::Result<String> {
 }
 
 /// Starts a built-in TFTP server serving files from the build output directory.
-pub fn run_tftp_server(tool: &Tool) -> anyhow::Result<()> {
-    let mut file_dir = tool.manifest_dir().clone();
-    if let Some(elf_path) = tool.runtime_artifacts().elf() {
+pub fn run_tftp_server(manifest_dir: &Path, artifacts: &OutputArtifacts) -> anyhow::Result<()> {
+    let mut file_dir = manifest_dir.to_path_buf();
+    if let Some(elf_path) = artifacts.elf() {
         file_dir = elf_path
             .parent()
             .ok_or(anyhow!("{} no parent dir", elf_path.display()))?

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -317,13 +317,12 @@ impl UbootRunInput {
         process_context: ProcessContext,
         artifacts: OutputArtifacts,
         arch: Option<object::Architecture>,
-    ) -> anyhow::Result<Self> {
-        artifacts.require_bin("U-Boot runner requires a prepared BIN artifact")?;
-        Ok(Self {
+    ) -> Self {
+        Self {
             process_context,
             artifacts,
             arch,
-        })
+        }
     }
 }
 
@@ -1127,7 +1126,8 @@ where
         let kernel = self
             .input
             .artifacts
-            .require_bin("bin not exist")?
+            .runtime_image()
+            .ok_or_else(|| anyhow!("U-Boot runner requires a prepared runtime image"))?
             .to_path_buf();
 
         info!("Starting U-Boot runner...");

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -28,7 +28,7 @@ use tokio_util::compat::{
 use uboot_shell::UbootShell;
 
 use crate::{
-    Tool,
+    artifact::state::OutputArtifacts,
     board::{
         client::{
             BoardServerClient, BootConfig as RemoteBootConfig, BootProfileResponse,
@@ -40,6 +40,7 @@ use crate::{
             BoxedAsyncRead, BoxedAsyncWrite, SerialStreamTasks, connect_serial_stream,
         },
     },
+    process::ProcessContext,
     project::variables::{self, VariableScope},
     run::{
         output_matcher::{
@@ -304,96 +305,89 @@ pub struct RunUbootOptions {
     pub show_output: bool,
 }
 
-impl Tool {
-    pub fn default_uboot_config(&self) -> UbootConfig {
-        UbootConfig {
-            local: LocalUbootConfig {
-                serial: Some("/dev/ttyUSB0".to_string()),
-                baud_rate: Some("115200".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }
-    }
+#[derive(Clone, Debug)]
+pub(crate) struct UbootRunInput {
+    process_context: ProcessContext,
+    artifacts: OutputArtifacts,
+    arch: Option<object::Architecture>,
+}
 
-    pub async fn read_uboot_config_from_path_for_cargo(
-        &mut self,
-        cargo: &crate::build::config::Cargo,
-        path: &Path,
-    ) -> anyhow::Result<UbootConfig> {
-        self.sync_cargo_context(cargo)?;
-        let scope = self.variable_scope()?;
-        let config_path = variables::expand_path_variables(path, &scope)?;
-        read_uboot_config_at_path(&scope, config_path).await
-    }
-
-    pub async fn ensure_uboot_config_for_cargo(
-        &mut self,
-        cargo: &crate::build::config::Cargo,
-    ) -> anyhow::Result<UbootConfig> {
-        self.sync_cargo_context(cargo)?;
-        let workspace_dir = self.workspace_dir().clone();
-        self.ensure_uboot_config_in_dir_for_cargo(cargo, &workspace_dir)
-            .await
-    }
-
-    pub async fn ensure_uboot_config_in_dir_for_cargo(
-        &mut self,
-        cargo: &crate::build::config::Cargo,
-        dir: &Path,
-    ) -> anyhow::Result<UbootConfig> {
-        self.sync_cargo_context(cargo)?;
-        let scope = self.variable_scope()?;
-        let dir = variables::expand_path_variables(dir, &scope)?;
-        ensure_uboot_config_at_path(&scope, dir.join(".uboot.toml"), self.default_uboot_config())
-            .await
-    }
-
-    pub async fn ensure_uboot_config_in_dir(&mut self, dir: &Path) -> anyhow::Result<UbootConfig> {
-        let scope = self.variable_scope()?;
-        let dir = variables::expand_path_variables(dir, &scope)?;
-        ensure_uboot_config_at_path(&scope, dir.join(".uboot.toml"), self.default_uboot_config())
-            .await
-    }
-
-    pub async fn read_uboot_config_from_path(
-        &mut self,
-        path: &Path,
-    ) -> anyhow::Result<UbootConfig> {
-        let scope = self.variable_scope()?;
-        let config_path = variables::expand_path_variables(path, &scope)?;
-        read_uboot_config_at_path(&scope, config_path).await
-    }
-
-    pub async fn run_uboot(
-        &mut self,
-        config: &UbootConfig,
-        options: RunUbootOptions,
-    ) -> anyhow::Result<()> {
-        let _ = options.show_output;
-        let mut config = config.clone();
-        let scope = self.variable_scope()?;
-        config.replace_strings(&scope)?;
-        config.normalize("U-Boot runtime config")?;
-        let backend = LocalBackend::new(config.local.clone());
-        let mut runner = Runner::new(self, config, backend);
-        runner.run().await
-    }
-
-    pub async fn run_uboot_remote(
-        &mut self,
-        board_config: &BoardRunConfig,
-        client: BoardServerClient,
-        session: SessionCreatedResponse,
-    ) -> anyhow::Result<()> {
-        let config = UbootConfig::from_board_run_config(board_config);
-        let backend = RemoteBackend::new(client, session);
-        let mut runner = Runner::new(self, config, backend);
-        runner.run().await
+impl UbootRunInput {
+    pub(crate) fn new(
+        process_context: ProcessContext,
+        artifacts: OutputArtifacts,
+        arch: Option<object::Architecture>,
+    ) -> anyhow::Result<Self> {
+        artifacts.require_bin("U-Boot runner requires a prepared BIN artifact")?;
+        Ok(Self {
+            process_context,
+            artifacts,
+            arch,
+        })
     }
 }
 
-async fn read_uboot_config_at_path(
+pub(crate) fn default_uboot_config() -> UbootConfig {
+    UbootConfig {
+        local: LocalUbootConfig {
+            serial: Some("/dev/ttyUSB0".to_string()),
+            baud_rate: Some("115200".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+pub(crate) async fn read_uboot_config_from_path(
+    variables: &VariableScope,
+    path: &Path,
+) -> anyhow::Result<UbootConfig> {
+    let config_path = variables::expand_path_variables(path, variables)?;
+    read_uboot_config_at_path(variables, config_path).await
+}
+
+pub(crate) async fn ensure_uboot_config_in_dir(
+    variables: &VariableScope,
+    dir: &Path,
+) -> anyhow::Result<UbootConfig> {
+    let dir = variables::expand_path_variables(dir, variables)?;
+    ensure_uboot_config_at_path(variables, dir.join(".uboot.toml"), default_uboot_config()).await
+}
+
+pub(crate) fn prepare_uboot_runtime_config(
+    variables: &VariableScope,
+    config: &UbootConfig,
+) -> anyhow::Result<UbootConfig> {
+    let mut config = config.clone();
+    config.replace_strings(variables)?;
+    config.normalize("U-Boot runtime config")?;
+    Ok(config)
+}
+
+pub(crate) async fn run_uboot_with_config(
+    input: UbootRunInput,
+    config: UbootConfig,
+    options: RunUbootOptions,
+) -> anyhow::Result<()> {
+    let _ = options.show_output;
+    let backend = LocalBackend::new(config.local.clone());
+    let mut runner = Runner::new(input, config, backend);
+    runner.run().await
+}
+
+pub(crate) async fn run_uboot_remote(
+    input: UbootRunInput,
+    board_config: &BoardRunConfig,
+    client: BoardServerClient,
+    session: SessionCreatedResponse,
+) -> anyhow::Result<()> {
+    let config = UbootConfig::from_board_run_config(board_config);
+    let backend = RemoteBackend::new(client, session);
+    let mut runner = Runner::new(input, config, backend);
+    runner.run().await
+}
+
+pub(crate) async fn read_uboot_config_at_path(
     variables: &VariableScope,
     config_path: PathBuf,
 ) -> anyhow::Result<UbootConfig> {
@@ -410,7 +404,7 @@ async fn read_uboot_config_at_path(
     Ok(config)
 }
 
-async fn ensure_uboot_config_at_path(
+pub(crate) async fn ensure_uboot_config_at_path(
     variables: &VariableScope,
     config_path: PathBuf,
     default_config: UbootConfig,
@@ -432,8 +426,8 @@ async fn ensure_uboot_config_at_path(
     Ok(config)
 }
 
-struct Runner<'a, B> {
-    tool: &'a mut Tool,
+struct Runner<B> {
+    input: UbootRunInput,
     config: UbootConfig,
     success_regex: Vec<regex::Regex>,
     fail_regex: Vec<regex::Regex>,
@@ -479,23 +473,23 @@ struct PreparedDtb {
 trait RunnerBackend {
     async fn resolve_runtime(
         &mut self,
-        tool: &mut Tool,
+        input: &UbootRunInput,
         config: &UbootConfig,
     ) -> anyhow::Result<ResolvedRuntime>;
     async fn prepare_dtb(
         &mut self,
-        tool: &Tool,
+        input: &UbootRunInput,
         config: &UbootConfig,
     ) -> anyhow::Result<PreparedDtb>;
     async fn open_console(&mut self) -> anyhow::Result<ConsoleTransport>;
-    async fn after_console_open(&mut self, tool: &Tool) -> anyhow::Result<()>;
+    async fn after_console_open(&mut self, context: &ProcessContext) -> anyhow::Result<()>;
     async fn stage_fit_image(
         &mut self,
         fitimage: &Path,
         runtime: &ResolvedRuntime,
     ) -> anyhow::Result<PreparedBootArtifact>;
     async fn finish_console(&mut self) -> anyhow::Result<()>;
-    async fn after_run(&mut self, tool: &Tool) -> anyhow::Result<()>;
+    async fn after_run(&mut self, context: &ProcessContext) -> anyhow::Result<()>;
 }
 
 struct LocalBackend {
@@ -522,7 +516,7 @@ impl LocalBackend {
 impl RunnerBackend for LocalBackend {
     async fn resolve_runtime(
         &mut self,
-        tool: &mut Tool,
+        input: &UbootRunInput,
         _config: &UbootConfig,
     ) -> anyhow::Result<ResolvedRuntime> {
         let baud_rate = self
@@ -571,7 +565,7 @@ impl RunnerBackend for LocalBackend {
                 && let Some(ip) = server_ip.as_ref()
             {
                 info!("TFTP server IP: {}", ip);
-                tftp::run_tftp_server(tool)?;
+                tftp::run_tftp_server(input.process_context.workdir(), &input.artifacts)?;
                 self.builtin_tftp_started = true;
             }
         }
@@ -583,7 +577,7 @@ impl RunnerBackend for LocalBackend {
                 && let Some(ip) = server_ip.as_ref()
             {
                 info!("TFTP server IP: {}", ip);
-                tftp::run_tftp_server(tool)?;
+                tftp::run_tftp_server(input.process_context.workdir(), &input.artifacts)?;
                 self.builtin_tftp_started = true;
             }
         }
@@ -620,7 +614,7 @@ impl RunnerBackend for LocalBackend {
 
     async fn prepare_dtb(
         &mut self,
-        _tool: &Tool,
+        _input: &UbootRunInput,
         config: &UbootConfig,
     ) -> anyhow::Result<PreparedDtb> {
         Ok(PreparedDtb {
@@ -651,13 +645,12 @@ impl RunnerBackend for LocalBackend {
         })
     }
 
-    async fn after_console_open(&mut self, tool: &Tool) -> anyhow::Result<()> {
+    async fn after_console_open(&mut self, context: &ProcessContext) -> anyhow::Result<()> {
         println!("Waiting for board on power or reset...");
         if let Some(cmd) = self.config.board_reset_cmd.as_deref()
             && !cmd.trim().is_empty()
         {
-            let process_context = tool.process_context()?;
-            crate::process::shell_run_cmd(&process_context, cmd)?;
+            crate::process::shell_run_cmd(context, cmd)?;
         }
         Ok(())
     }
@@ -713,12 +706,10 @@ impl RunnerBackend for LocalBackend {
         Ok(())
     }
 
-    async fn after_run(&mut self, tool: &Tool) -> anyhow::Result<()> {
+    async fn after_run(&mut self, context: &ProcessContext) -> anyhow::Result<()> {
         if let Some(cmd) = self.config.board_power_off_cmd.as_deref()
             && !cmd.trim().is_empty()
-            && let Err(err) = tool
-                .process_context()
-                .and_then(|context| crate::process::shell_run_cmd(&context, cmd))
+            && let Err(err) = crate::process::shell_run_cmd(context, cmd)
         {
             log::warn!("board power-off command failed: {err:#}");
         }
@@ -754,7 +745,7 @@ impl RemoteBackend {
 impl RunnerBackend for RemoteBackend {
     async fn resolve_runtime(
         &mut self,
-        _tool: &mut Tool,
+        _input: &UbootRunInput,
         _config: &UbootConfig,
     ) -> anyhow::Result<ResolvedRuntime> {
         let boot_profile = self
@@ -845,7 +836,7 @@ impl RunnerBackend for RemoteBackend {
 
     async fn prepare_dtb(
         &mut self,
-        tool: &Tool,
+        input: &UbootRunInput,
         config: &UbootConfig,
     ) -> anyhow::Result<PreparedDtb> {
         let session_dtb = self
@@ -901,8 +892,8 @@ impl RunnerBackend for RemoteBackend {
                     self.session.session_id
                 )
             })?;
-        let output_dir = tool
-            .runtime_artifacts()
+        let output_dir = input
+            .artifacts
             .runtime_artifact_dir()
             .map(PathBuf::from)
             .unwrap_or_else(std::env::temp_dir);
@@ -935,7 +926,7 @@ impl RunnerBackend for RemoteBackend {
         Ok(ConsoleTransport { tx, rx })
     }
 
-    async fn after_console_open(&mut self, _tool: &Tool) -> anyhow::Result<()> {
+    async fn after_console_open(&mut self, _context: &ProcessContext) -> anyhow::Result<()> {
         println!("Waiting for remote board to power on through ostool-server...");
         Ok(())
     }
@@ -988,18 +979,18 @@ impl RunnerBackend for RemoteBackend {
         Ok(())
     }
 
-    async fn after_run(&mut self, _tool: &Tool) -> anyhow::Result<()> {
+    async fn after_run(&mut self, _context: &ProcessContext) -> anyhow::Result<()> {
         Ok(())
     }
 }
 
-impl<'a, B> Runner<'a, B>
+impl<B> Runner<B>
 where
     B: RunnerBackend,
 {
-    fn new(tool: &'a mut Tool, config: UbootConfig, backend: B) -> Self {
+    fn new(input: UbootRunInput, config: UbootConfig, backend: B) -> Self {
         Self {
-            tool,
+            input,
             config,
             success_regex: vec![],
             fail_regex: vec![],
@@ -1036,8 +1027,8 @@ where
         );
 
         let arch = self
-            .tool
-            .runtime_arch()
+            .input
+            .arch
             .ok_or_else(|| anyhow!("Cannot determine architecture for FIT image generation"))?;
         let arch = match arch {
             object::Architecture::Aarch64 => "arm64",
@@ -1120,7 +1111,7 @@ where
             log::warn!("backend console cleanup failed: {err:#}");
         }
 
-        if let Err(err) = self.backend.after_run(self.tool).await {
+        if let Err(err) = self.backend.after_run(&self.input.process_context).await {
             if run_result.is_ok() {
                 return Err(err);
             }
@@ -1132,11 +1123,10 @@ where
 
     async fn _run(&mut self) -> anyhow::Result<()> {
         self.prepare_regex()?;
-        self.tool.ensure_runtime_bin()?;
 
         let kernel = self
-            .tool
-            .runtime_artifacts()
+            .input
+            .artifacts
             .require_bin("bin not exist")?
             .to_path_buf();
 
@@ -1146,14 +1136,16 @@ where
 
         let runtime = self
             .backend
-            .resolve_runtime(self.tool, &self.config)
+            .resolve_runtime(&self.input, &self.config)
             .await?;
-        let prepared_dtb = self.backend.prepare_dtb(self.tool, &self.config).await?;
+        let prepared_dtb = self.backend.prepare_dtb(&self.input, &self.config).await?;
         if let Some(interface) = runtime.interface.as_deref() {
             info!("Using network interface hint: {interface}");
         }
         let ConsoleTransport { tx, rx } = self.backend.open_console().await?;
-        self.backend.after_console_open(self.tool).await?;
+        self.backend
+            .after_console_open(&self.input.process_context)
+            .await?;
 
         let mut net_ok = false;
         let mut uboot = UbootShell::new(tx, rx).await?;

--- a/ostool/src/tool.rs
+++ b/ostool/src/tool.rs
@@ -465,12 +465,12 @@ impl Tool {
         if config.to_bin {
             self.ensure_runtime_bin()?;
         }
-        let input = crate::run::qemu::QemuRunInput {
-            process_context: self.process_context()?,
-            artifacts: self.runtime_artifacts().clone(),
-            arch: self.runtime_arch(),
-            debug: self.debug_enabled(),
-        };
+        let input = crate::run::qemu::QemuRunInput::new(
+            self.process_context()?,
+            self.runtime_artifacts().clone(),
+            self.runtime_arch(),
+            self.debug_enabled(),
+        );
         crate::run::qemu::run_qemu_with_config(input, options, config).await
     }
 

--- a/ostool/src/tool.rs
+++ b/ostool/src/tool.rs
@@ -545,7 +545,7 @@ impl Tool {
     ) -> anyhow::Result<()> {
         let scope = self.variable_scope()?;
         let config = crate::run::uboot::prepare_uboot_runtime_config(&scope, config)?;
-        let input = self.prepared_uboot_run_input()?;
+        let input = self.uboot_run_input()?;
         crate::run::uboot::run_uboot_with_config(input, config, options).await
     }
 
@@ -557,27 +557,18 @@ impl Tool {
         client: crate::board::client::BoardServerClient,
         session: crate::board::client::SessionCreatedResponse,
     ) -> anyhow::Result<()> {
-        let input = self.prepared_uboot_run_input()?;
+        let input = self.uboot_run_input()?;
         crate::run::uboot::run_uboot_remote(input, board_config, client, session).await
     }
 
     /// Compatibility helper for the legacy `Tool` API.
     /// Remove this method when callers use explicit runner inputs.
     pub(crate) fn uboot_run_input(&self) -> anyhow::Result<crate::run::uboot::UbootRunInput> {
-        crate::run::uboot::UbootRunInput::new(
+        Ok(crate::run::uboot::UbootRunInput::new(
             self.process_context()?,
             self.runtime_artifacts().clone(),
             self.runtime_arch(),
-        )
-    }
-
-    /// Compatibility helper for the legacy `Tool` API.
-    /// Remove this method when callers use explicit runner inputs.
-    pub(crate) fn prepared_uboot_run_input(
-        &mut self,
-    ) -> anyhow::Result<crate::run::uboot::UbootRunInput> {
-        self.ensure_runtime_bin()?;
-        self.uboot_run_input()
+        ))
     }
 
     /// Compatibility wrapper for the legacy `Tool` API.
@@ -669,7 +660,7 @@ impl Tool {
         options: crate::board::RunBoardOptions,
     ) -> anyhow::Result<()> {
         self.prepare_runtime_artifacts(build_config, false).await?;
-        let input = self.prepared_uboot_run_input()?;
+        let input = self.uboot_run_input()?;
         let scope = self.variable_scope()?;
         crate::board::run_prepared_board(input, board_config, options, &scope).await
     }
@@ -692,22 +683,6 @@ mod tests {
         fs,
         path::{Path, PathBuf},
     };
-
-    #[cfg(unix)]
-    fn fake_objcopy(root: &Path) -> PathBuf {
-        let script = root.join("fake-rust-objcopy");
-        fs::write(
-            &script,
-            "#!/bin/sh\nlast=\"\"\nprev=\"\"\nfor arg in \"$@\"; do prev=\"$last\"; last=\"$arg\"; done\ncp \"$prev\" \"$last\"\n",
-        )
-        .unwrap();
-
-        use std::os::unix::fs::PermissionsExt;
-        let mut permissions = fs::metadata(&script).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&script, permissions).unwrap();
-        script
-    }
 
     #[tokio::test]
     async fn apply_prepared_runtime_artifacts_updates_dirs_and_arch() {
@@ -764,7 +739,7 @@ mod tests {
     }
 
     #[test]
-    fn uboot_run_input_rejects_artifacts_without_bin() {
+    fn uboot_run_input_accepts_elf_only_artifacts() {
         let temp = tempfile::tempdir().unwrap();
         write_single_package(temp.path(), "sample");
         let source = std::env::current_exe().unwrap();
@@ -792,45 +767,32 @@ mod tests {
         .unwrap();
         tool.apply_prepared_runtime_artifacts(prepared);
 
-        let err = tool.uboot_run_input().unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("U-Boot runner requires a prepared BIN artifact")
-        );
+        tool.uboot_run_input().unwrap();
+        assert!(tool.ctx.artifacts.elf().is_some());
+        assert!(tool.ctx.artifacts.bin().is_none());
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn prepared_uboot_run_input_reuses_existing_bin() {
+    #[tokio::test]
+    async fn run_uboot_rejects_missing_runtime_image() {
         let temp = tempfile::tempdir().unwrap();
         write_single_package(temp.path(), "sample");
-        let source = std::env::current_exe().unwrap();
-        let copied = temp.path().join("sample-elf");
-        fs::copy(&source, &copied).unwrap();
-
         let mut tool = Tool::new(ToolConfig {
             manifest: Some(temp.path().to_path_buf()),
             ..Default::default()
         })
         .unwrap();
-        let process_context = tool.process_context().unwrap();
-        let prepared = prepare_runtime_artifacts(
-            &process_context,
-            RuntimeArtifactOptions {
-                elf_path: copied,
-                to_bin: true,
-                bin_dir: None,
-                debug: false,
-                cargo_artifact_dir: None,
-                strip_elf: false,
-                objcopy_program: fake_objcopy(temp.path()),
-            },
-        )
-        .unwrap();
-        tool.apply_prepared_runtime_artifacts(prepared);
 
-        tool.prepared_uboot_run_input().unwrap();
-        assert!(tool.ctx.artifacts.bin().is_some());
+        let err = tool
+            .run_uboot(
+                &crate::run::uboot::UbootConfig::default(),
+                crate::run::uboot::RunUbootOptions::default(),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("U-Boot runner requires a prepared runtime image")
+        );
     }
 
     #[test]

--- a/ostool/src/tool.rs
+++ b/ostool/src/tool.rs
@@ -182,10 +182,6 @@ impl Tool {
         legacy_context::set_active_build(&mut self.state, &mut self.ctx, active_build);
     }
 
-    pub(crate) fn manifest_dir(&self) -> &PathBuf {
-        &self.manifest_dir
-    }
-
     pub(crate) fn workspace_dir(&self) -> &PathBuf {
         &self.workspace_dir
     }
@@ -372,6 +368,311 @@ impl Tool {
     pub(crate) fn ui_hooks(&self) -> Vec<ElementHook> {
         config_hooks::build_config_hooks(&self.workspace_dir)
     }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit QEMU module function.
+    /// Returns the default QEMU runtime configuration for the current tool context.
+    pub fn default_qemu_config(&self) -> crate::run::qemu::QemuConfig {
+        crate::run::qemu::default_qemu_config(self.runtime_arch())
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit QEMU module function.
+    /// Returns the default QEMU runtime configuration for a Cargo build config.
+    pub fn default_qemu_config_for_cargo(&self, cargo: &Cargo) -> crate::run::qemu::QemuConfig {
+        crate::run::qemu::default_qemu_config_for_cargo(cargo, self.runtime_arch())
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit QEMU module function.
+    pub async fn read_qemu_config_from_path_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+        path: &std::path::Path,
+    ) -> anyhow::Result<crate::run::qemu::QemuConfig> {
+        self.sync_cargo_context(cargo)?;
+        let scope = self.variable_scope()?;
+        crate::run::qemu::read_qemu_config_from_path(&scope, path).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit QEMU module function.
+    pub async fn ensure_qemu_config_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+    ) -> anyhow::Result<crate::run::qemu::QemuConfig> {
+        self.sync_cargo_context(cargo)?;
+        let scope = self.variable_scope()?;
+        crate::run::qemu::ensure_qemu_config_for_cargo(
+            &self.project_layout(),
+            &scope,
+            cargo,
+            self.runtime_arch(),
+        )
+        .await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit QEMU module function.
+    pub async fn ensure_qemu_config_in_dir_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+        dir: &std::path::Path,
+    ) -> anyhow::Result<crate::run::qemu::QemuConfig> {
+        self.sync_cargo_context(cargo)?;
+        let scope = self.variable_scope()?;
+        crate::run::qemu::ensure_qemu_config_in_dir_for_cargo(
+            &scope,
+            cargo,
+            dir,
+            self.runtime_arch(),
+        )
+        .await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit QEMU module function.
+    /// Loads a QEMU configuration from a directory using the default filename search.
+    pub async fn ensure_qemu_config_in_dir(
+        &mut self,
+        dir: &std::path::Path,
+    ) -> anyhow::Result<crate::run::qemu::QemuConfig> {
+        let scope = self.variable_scope()?;
+        crate::run::qemu::ensure_qemu_config_in_dir(&scope, dir, self.runtime_arch()).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit QEMU module function.
+    /// Reads a QEMU configuration from an explicit path without creating defaults.
+    pub async fn read_qemu_config_from_path(
+        &mut self,
+        path: &std::path::Path,
+    ) -> anyhow::Result<crate::run::qemu::QemuConfig> {
+        let scope = self.variable_scope()?;
+        crate::run::qemu::read_qemu_config_from_path(&scope, path).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit QEMU module function.
+    /// Runs an already prepared artifact in QEMU using a fully materialized configuration.
+    pub async fn run_qemu(
+        &mut self,
+        config: &crate::run::qemu::QemuConfig,
+        options: crate::run::qemu::RunQemuOptions,
+    ) -> anyhow::Result<()> {
+        let scope = self.variable_scope()?;
+        let config = crate::run::qemu::prepare_qemu_runtime_config(&scope, config)?;
+        if config.to_bin {
+            self.ensure_runtime_bin()?;
+        }
+        let input = crate::run::qemu::QemuRunInput {
+            process_context: self.process_context()?,
+            artifacts: self.runtime_artifacts().clone(),
+            arch: self.runtime_arch(),
+            debug: self.debug_enabled(),
+        };
+        crate::run::qemu::run_qemu_with_config(input, options, config).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit U-Boot module function.
+    pub fn default_uboot_config(&self) -> crate::run::uboot::UbootConfig {
+        crate::run::uboot::default_uboot_config()
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit U-Boot module function.
+    pub async fn read_uboot_config_from_path_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+        path: &std::path::Path,
+    ) -> anyhow::Result<crate::run::uboot::UbootConfig> {
+        self.sync_cargo_context(cargo)?;
+        let scope = self.variable_scope()?;
+        crate::run::uboot::read_uboot_config_from_path(&scope, path).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit U-Boot module function.
+    pub async fn ensure_uboot_config_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+    ) -> anyhow::Result<crate::run::uboot::UbootConfig> {
+        self.sync_cargo_context(cargo)?;
+        let workspace_dir = self.workspace_dir().clone();
+        self.ensure_uboot_config_in_dir_for_cargo(cargo, &workspace_dir)
+            .await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit U-Boot module function.
+    pub async fn ensure_uboot_config_in_dir_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+        dir: &std::path::Path,
+    ) -> anyhow::Result<crate::run::uboot::UbootConfig> {
+        self.sync_cargo_context(cargo)?;
+        let scope = self.variable_scope()?;
+        crate::run::uboot::ensure_uboot_config_in_dir(&scope, dir).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit U-Boot module function.
+    pub async fn ensure_uboot_config_in_dir(
+        &mut self,
+        dir: &std::path::Path,
+    ) -> anyhow::Result<crate::run::uboot::UbootConfig> {
+        let scope = self.variable_scope()?;
+        crate::run::uboot::ensure_uboot_config_in_dir(&scope, dir).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit U-Boot module function.
+    pub async fn read_uboot_config_from_path(
+        &mut self,
+        path: &std::path::Path,
+    ) -> anyhow::Result<crate::run::uboot::UbootConfig> {
+        let scope = self.variable_scope()?;
+        crate::run::uboot::read_uboot_config_from_path(&scope, path).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit U-Boot module function.
+    pub async fn run_uboot(
+        &mut self,
+        config: &crate::run::uboot::UbootConfig,
+        options: crate::run::uboot::RunUbootOptions,
+    ) -> anyhow::Result<()> {
+        let scope = self.variable_scope()?;
+        let config = crate::run::uboot::prepare_uboot_runtime_config(&scope, config)?;
+        let input = self.prepared_uboot_run_input()?;
+        crate::run::uboot::run_uboot_with_config(input, config, options).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit U-Boot module function.
+    pub async fn run_uboot_remote(
+        &mut self,
+        board_config: &crate::board::config::BoardRunConfig,
+        client: crate::board::client::BoardServerClient,
+        session: crate::board::client::SessionCreatedResponse,
+    ) -> anyhow::Result<()> {
+        let input = self.prepared_uboot_run_input()?;
+        crate::run::uboot::run_uboot_remote(input, board_config, client, session).await
+    }
+
+    /// Compatibility helper for the legacy `Tool` API.
+    /// Remove this method when callers use explicit runner inputs.
+    pub(crate) fn uboot_run_input(&self) -> anyhow::Result<crate::run::uboot::UbootRunInput> {
+        crate::run::uboot::UbootRunInput::new(
+            self.process_context()?,
+            self.runtime_artifacts().clone(),
+            self.runtime_arch(),
+        )
+    }
+
+    /// Compatibility helper for the legacy `Tool` API.
+    /// Remove this method when callers use explicit runner inputs.
+    pub(crate) fn prepared_uboot_run_input(
+        &mut self,
+    ) -> anyhow::Result<crate::run::uboot::UbootRunInput> {
+        self.ensure_runtime_bin()?;
+        self.uboot_run_input()
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit board module function.
+    pub fn default_board_run_config(&self) -> crate::board::config::BoardRunConfig {
+        crate::board::config::BoardRunConfig::default()
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit board module function.
+    pub async fn read_board_run_config_from_path_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+        path: &std::path::Path,
+    ) -> anyhow::Result<crate::board::config::BoardRunConfig> {
+        self.sync_cargo_context(cargo)?;
+        let scope = self.variable_scope()?;
+        crate::board::read_board_run_config_from_path(&scope, path).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit board module function.
+    pub async fn ensure_board_run_config_in_dir_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+        dir: &std::path::Path,
+    ) -> anyhow::Result<crate::board::config::BoardRunConfig> {
+        self.sync_cargo_context(cargo)?;
+        let scope = self.variable_scope()?;
+        crate::board::ensure_board_run_config_in_dir(&scope, dir).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit board module function.
+    pub async fn ensure_board_run_config_in_dir(
+        &mut self,
+        dir: &std::path::Path,
+    ) -> anyhow::Result<crate::board::config::BoardRunConfig> {
+        let scope = self.variable_scope()?;
+        crate::board::ensure_board_run_config_in_dir(&scope, dir).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit board module function.
+    pub async fn read_board_run_config_from_path(
+        &mut self,
+        path: &std::path::Path,
+    ) -> anyhow::Result<crate::board::config::BoardRunConfig> {
+        let scope = self.variable_scope()?;
+        crate::board::read_board_run_config_from_path(&scope, path).await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit board module function.
+    pub async fn run_board(
+        &mut self,
+        build_config: &BuildConfig,
+        board_config: &crate::board::config::BoardRunConfig,
+        options: crate::board::RunBoardOptions,
+    ) -> anyhow::Result<()> {
+        self.run_board_with_build_config(build_config, board_config, options)
+            .await
+    }
+
+    /// Compatibility wrapper for the legacy `Tool` API.
+    /// Remove this method when callers use the explicit board module function.
+    pub async fn cargo_run_board(
+        &mut self,
+        cargo: &Cargo,
+        board_config: &crate::board::config::BoardRunConfig,
+        options: crate::board::RunBoardOptions,
+    ) -> anyhow::Result<()> {
+        self.sync_cargo_context(cargo)?;
+        self.run_board_with_build_config(
+            &BuildConfig {
+                system: BuildSystem::Cargo(cargo.clone()),
+            },
+            board_config,
+            options,
+        )
+        .await
+    }
+
+    // Compatibility helper for the legacy `Tool` board wrappers; remove it with them.
+    async fn run_board_with_build_config(
+        &mut self,
+        build_config: &BuildConfig,
+        board_config: &crate::board::config::BoardRunConfig,
+        options: crate::board::RunBoardOptions,
+    ) -> anyhow::Result<()> {
+        self.prepare_runtime_artifacts(build_config, false).await?;
+        let input = self.prepared_uboot_run_input()?;
+        let scope = self.variable_scope()?;
+        crate::board::run_prepared_board(input, board_config, options, &scope).await
+    }
 }
 
 pub fn resolve_manifest_context(input: Option<PathBuf>) -> anyhow::Result<ManifestContext> {
@@ -391,6 +692,22 @@ mod tests {
         fs,
         path::{Path, PathBuf},
     };
+
+    #[cfg(unix)]
+    fn fake_objcopy(root: &Path) -> PathBuf {
+        let script = root.join("fake-rust-objcopy");
+        fs::write(
+            &script,
+            "#!/bin/sh\nlast=\"\"\nprev=\"\"\nfor arg in \"$@\"; do prev=\"$last\"; last=\"$arg\"; done\ncp \"$prev\" \"$last\"\n",
+        )
+        .unwrap();
+
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
+        script
+    }
 
     #[tokio::test]
     async fn apply_prepared_runtime_artifacts_updates_dirs_and_arch() {
@@ -444,6 +761,76 @@ mod tests {
         );
         assert!(tool.ctx.arch.is_some());
         assert!(tool.ctx.artifacts.bin().is_none());
+    }
+
+    #[test]
+    fn uboot_run_input_rejects_artifacts_without_bin() {
+        let temp = tempfile::tempdir().unwrap();
+        write_single_package(temp.path(), "sample");
+        let source = std::env::current_exe().unwrap();
+        let copied = temp.path().join("sample-elf");
+        fs::copy(&source, &copied).unwrap();
+
+        let mut tool = Tool::new(ToolConfig {
+            manifest: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        })
+        .unwrap();
+        let process_context = tool.process_context().unwrap();
+        let prepared = prepare_runtime_artifacts(
+            &process_context,
+            RuntimeArtifactOptions {
+                elf_path: copied,
+                to_bin: false,
+                bin_dir: None,
+                debug: false,
+                cargo_artifact_dir: None,
+                strip_elf: false,
+                objcopy_program: PathBuf::from("rust-objcopy"),
+            },
+        )
+        .unwrap();
+        tool.apply_prepared_runtime_artifacts(prepared);
+
+        let err = tool.uboot_run_input().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("U-Boot runner requires a prepared BIN artifact")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepared_uboot_run_input_reuses_existing_bin() {
+        let temp = tempfile::tempdir().unwrap();
+        write_single_package(temp.path(), "sample");
+        let source = std::env::current_exe().unwrap();
+        let copied = temp.path().join("sample-elf");
+        fs::copy(&source, &copied).unwrap();
+
+        let mut tool = Tool::new(ToolConfig {
+            manifest: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        })
+        .unwrap();
+        let process_context = tool.process_context().unwrap();
+        let prepared = prepare_runtime_artifacts(
+            &process_context,
+            RuntimeArtifactOptions {
+                elf_path: copied,
+                to_bin: true,
+                bin_dir: None,
+                debug: false,
+                cargo_artifact_dir: None,
+                strip_elf: false,
+                objcopy_program: fake_objcopy(temp.path()),
+            },
+        )
+        .unwrap();
+        tool.apply_prepared_runtime_artifacts(prepared);
+
+        tool.prepared_uboot_run_input().unwrap();
+        assert!(tool.ctx.artifacts.bin().is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- 将 QEMU、U-Boot 和 board runner 从直接挂在 `Tool` 上的实现拆到模块级函数，运行入口改为接收显式的 process context、artifacts、arch/debug 等输入。
- 保留现有 `Tool` runner/config 方法作为兼容 wrapper，并逐函数标注这些旧入口会在调用方迁移后移除。
- 将 TFTP 和 menuconfig 相关路径解析改为使用显式项目布局、变量作用域和运行产物状态，减少 runner 模块对完整 `Tool` 的依赖。
- `legacy_context` 继续只负责 `InvocationState` 与旧 `AppContext` 的状态桥接，并标注这些桥接 helper 的临时性质。

## Approach

这次变更保留 `Tool` 作为现有 public API 的兼容 facade，但让 QEMU、U-Boot、board 和 TFTP 的核心流程依赖更窄的输入结构。`Tool` 负责把当前 invocation/build/runtime state 组装成 runner input，然后委托给对应模块函数；新代码可以直接调用模块级 API，旧调用方仍可通过 `Tool` 方法工作。

## Changed Modules

- `ostool/src/run/qemu.rs`: 提供显式 `QemuRunInput` 和模块级 QEMU config/run helper。
- `ostool/src/run/uboot.rs`: 提供显式 `UbootRunInput`，并让本地/远程 U-Boot runner 消费该输入。
- `ostool/src/run/tftp.rs`: TFTP server helper 改为接收 manifest dir 和 runtime artifacts，而不是完整 `Tool`。
- `ostool/src/board/mod.rs`: board run config 与 prepared board flow 改为使用显式 scope/input。
- `ostool/src/menuconfig.rs`: QEMU config path 查询改为走显式 workspace/runtime arch。
- `ostool/src/tool.rs`: 收敛为兼容 facade，保留旧 public runner/config 入口并委托到模块函数。
- `ostool/src/legacy_context.rs`: 标注旧 `AppContext` 桥接 helper 的兼容层性质。

## Compatibility

- CLI、配置文件格式和 runtime 行为预期保持不变。
- 既有 `Tool` public runner/config 方法仍保留，调用方不需要立即迁移。
- 新增的 runner input/helper 主要用于缩小内部模块依赖面，不新增用户可见配置项。

## Verification

已运行通过：

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo check -p ostool --target x86_64-unknown-linux-gnu --all-features`
- `CARGO_BUILD_JOBS=1 cargo test -p ostool -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo clippy -p ostool --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo build -p ostool --target x86_64-unknown-linux-gnu --all-features`
- `git diff --check`

## Risks / Follow-up

- 本 PR 只做 host-side Rust 验证，没有实际启动 QEMU、U-Boot 或远程开发板 session。
- `Tool` 兼容 facade 仍然存在；后续调用方迁移完成后，可以删除这些旧入口和对应桥接 helper。