### PR TITLE
refactor(tool): 收敛 artifact 生命周期边界

### DIFF
--- a/ostool/src/artifact/mod.rs
+++ b/ostool/src/artifact/mod.rs
@@ -1,4 +1,5 @@
 //! Runtime artifact preparation and state tracking.
 
+pub(crate) mod object_tools;
 pub(crate) mod runtime;
 pub(crate) mod state;

--- a/ostool/src/artifact/object_tools.rs
+++ b/ostool/src/artifact/object_tools.rs
@@ -1,0 +1,64 @@
+//! Rust object tool lookup helpers.
+
+use std::path::PathBuf;
+
+/// Rust toolchain object tools used by artifact preparation and analysis.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ObjectToolKind {
+    Objcopy,
+    Objdump,
+    Readobj,
+    Nm,
+}
+
+impl ObjectToolKind {
+    fn rust_program(self) -> &'static str {
+        match self {
+            Self::Objcopy => "rust-objcopy",
+            Self::Objdump => "rust-objdump",
+            Self::Readobj => "rust-readobj",
+            Self::Nm => "rust-nm",
+        }
+    }
+}
+
+/// Default Rust object tools.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ObjectTools;
+
+impl ObjectTools {
+    pub(crate) fn program(&self, kind: ObjectToolKind) -> PathBuf {
+        PathBuf::from(kind.rust_program())
+    }
+
+    pub(crate) fn objcopy(&self) -> PathBuf {
+        self.program(ObjectToolKind::Objcopy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{ObjectToolKind, ObjectTools};
+
+    #[test]
+    fn default_object_tools_use_rust_tool_names() {
+        let tools = ObjectTools;
+
+        assert_eq!(
+            tools.program(ObjectToolKind::Objcopy),
+            PathBuf::from("rust-objcopy")
+        );
+        assert_eq!(
+            tools.program(ObjectToolKind::Objdump),
+            PathBuf::from("rust-objdump")
+        );
+        assert_eq!(
+            tools.program(ObjectToolKind::Readobj),
+            PathBuf::from("rust-readobj")
+        );
+        assert_eq!(tools.program(ObjectToolKind::Nm), PathBuf::from("rust-nm"));
+    }
+}

--- a/ostool/src/artifact/runtime.rs
+++ b/ostool/src/artifact/runtime.rs
@@ -37,6 +37,7 @@ pub(crate) struct RuntimeArtifactOptions {
 pub(crate) struct PreparedRuntimeArtifacts {
     elf: PathBuf,
     bin: Option<PathBuf>,
+    source_artifact_dir: PathBuf,
     cargo_artifact_dir: Option<PathBuf>,
     runtime_artifact_dir: Option<PathBuf>,
     arch: Option<Architecture>,
@@ -55,6 +56,13 @@ impl PreparedRuntimeArtifacts {
 
     /// Returns the Cargo artifact directory that produced the input ELF.
     pub(crate) fn cargo_artifact_dir(&self) -> Option<&Path> {
+        self.cargo_artifact_dir
+            .as_deref()
+            .or(Some(self.source_artifact_dir.as_path()))
+    }
+
+    /// Returns the Cargo-reported artifact directory, when the input came from Cargo.
+    pub(crate) fn cargo_source_artifact_dir(&self) -> Option<&Path> {
         self.cargo_artifact_dir.as_deref()
     }
 
@@ -93,7 +101,8 @@ pub(crate) fn prepare_runtime_artifacts(
     let mut prepared = PreparedRuntimeArtifacts {
         elf: runtime_elf.clone(),
         bin: None,
-        cargo_artifact_dir: options.cargo_artifact_dir.or(Some(input_dir)),
+        source_artifact_dir: input_dir,
+        cargo_artifact_dir: options.cargo_artifact_dir,
         runtime_artifact_dir: runtime_elf.parent().map(PathBuf::from),
         arch: Some(arch),
     };
@@ -282,6 +291,10 @@ mod tests {
             prepared.cargo_artifact_dir(),
             Some(temp.path().join("target/debug").as_path())
         );
+        assert_eq!(
+            prepared.cargo_source_artifact_dir(),
+            Some(temp.path().join("target/debug").as_path())
+        );
         assert_eq!(prepared.runtime_artifact_dir(), Some(temp.path()));
         assert!(prepared.arch().is_some());
         assert!(expected_elf.exists());
@@ -313,6 +326,8 @@ mod tests {
 
         let expected_bin = bin_dir.join("sample.bin");
         assert_eq!(prepared.bin(), Some(expected_bin.as_path()));
+        assert_eq!(prepared.cargo_artifact_dir(), Some(temp.path()));
+        assert!(prepared.cargo_source_artifact_dir().is_none());
         assert_eq!(prepared.runtime_artifact_dir(), Some(bin_dir.as_path()));
         assert!(expected_bin.exists());
     }

--- a/ostool/src/artifact/state.rs
+++ b/ostool/src/artifact/state.rs
@@ -1,5 +1,6 @@
-//! Runtime artifact state shared by build orchestration and runners.
+//! Artifact state shared by build orchestration and runners.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
@@ -9,35 +10,95 @@ use crate::artifact::runtime::PreparedRuntimeArtifacts;
 /// Runtime artifacts prepared from a build output.
 #[derive(Default, Clone, Debug)]
 pub struct OutputArtifacts {
-    /// Path to the built ELF file.
+    cargo: Option<CargoArtifactState>,
+    runtime: RuntimeArtifactState,
+    #[allow(dead_code)]
+    debug: DebugArtifactRegistry,
+}
+
+#[derive(Clone, Debug)]
+struct CargoArtifactState {
+    #[allow(dead_code)]
+    elf: PathBuf,
+    artifact_dir: PathBuf,
+}
+
+#[derive(Default, Clone, Debug)]
+struct RuntimeArtifactState {
     elf: Option<PathBuf>,
-    /// Path to the converted binary file.
     bin: Option<PathBuf>,
-    /// Cargo-reported directory containing the original ELF artifact.
-    cargo_artifact_dir: Option<PathBuf>,
-    /// Directory containing the runtime artifact consumed by runners.
-    runtime_artifact_dir: Option<PathBuf>,
+    artifact_dir: Option<PathBuf>,
+    source_artifact_dir: Option<PathBuf>,
+}
+
+#[allow(dead_code)]
+#[derive(Default, Clone, Debug)]
+pub(crate) struct DebugArtifactRegistry {
+    artifacts: BTreeMap<DebugArtifactKind, DebugArtifact>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DebugArtifact {
+    kind: DebugArtifactKind,
+    path: PathBuf,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum DebugArtifactKind {
+    Disassembly,
+    ElfInfo,
+    Symbols,
+}
+
+#[allow(dead_code)]
+impl DebugArtifactRegistry {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.artifacts.is_empty()
+    }
+
+    pub(crate) fn register(&mut self, kind: DebugArtifactKind, path: PathBuf) {
+        self.artifacts.insert(kind, DebugArtifact { kind, path });
+    }
+
+    pub(crate) fn get(&self, kind: DebugArtifactKind) -> Option<&Path> {
+        self.artifacts
+            .get(&kind)
+            .map(|artifact| artifact.path.as_path())
+    }
 }
 
 impl OutputArtifacts {
     /// Returns the stripped runtime ELF path, when one has been prepared.
     pub fn elf(&self) -> Option<&Path> {
-        self.elf.as_deref()
+        self.runtime.elf.as_deref()
     }
 
     /// Returns the raw binary image path, when one has been prepared.
     pub fn bin(&self) -> Option<&Path> {
-        self.bin.as_deref()
+        self.runtime.bin.as_deref()
     }
 
-    /// Returns the Cargo artifact directory that produced the runtime ELF.
+    /// Returns the artifact directory that produced the runtime ELF.
+    #[allow(dead_code)]
     pub fn cargo_artifact_dir(&self) -> Option<&Path> {
-        self.cargo_artifact_dir.as_deref()
+        self.cargo
+            .as_ref()
+            .map(|cargo| cargo.artifact_dir.as_path())
+            .or(self.runtime.source_artifact_dir.as_deref())
+    }
+
+    /// Returns the Cargo source artifact directory, when the source came from Cargo.
+    pub(crate) fn cargo_source_artifact_dir(&self) -> Option<&Path> {
+        self.cargo
+            .as_ref()
+            .map(|cargo| cargo.artifact_dir.as_path())
     }
 
     /// Returns the directory containing the runtime artifacts consumed by runners.
     pub fn runtime_artifact_dir(&self) -> Option<&Path> {
-        self.runtime_artifact_dir.as_deref()
+        self.runtime.artifact_dir.as_deref()
     }
 
     /// Returns the preferred image path for runners that can load BIN or ELF.
@@ -52,14 +113,61 @@ impl OutputArtifacts {
 
     #[cfg(test)]
     pub(crate) fn set_runtime_artifact_dir(&mut self, path: PathBuf) {
-        self.runtime_artifact_dir = Some(path);
+        self.runtime.artifact_dir = Some(path);
     }
 
     /// Replaces artifact state from a prepared runtime artifact set.
     pub(crate) fn apply_prepared_runtime_artifacts(&mut self, prepared: &PreparedRuntimeArtifacts) {
-        self.elf = Some(prepared.elf().to_path_buf());
-        self.bin = prepared.bin().map(PathBuf::from);
-        self.cargo_artifact_dir = prepared.cargo_artifact_dir().map(PathBuf::from);
-        self.runtime_artifact_dir = prepared.runtime_artifact_dir().map(PathBuf::from);
+        self.cargo = prepared
+            .cargo_source_artifact_dir()
+            .map(|artifact_dir| CargoArtifactState {
+                elf: prepared.elf().to_path_buf(),
+                artifact_dir: artifact_dir.to_path_buf(),
+            });
+        self.runtime.elf = Some(prepared.elf().to_path_buf());
+        self.runtime.bin = prepared.bin().map(PathBuf::from);
+        self.runtime.artifact_dir = prepared.runtime_artifact_dir().map(PathBuf::from);
+        self.runtime.source_artifact_dir = prepared.cargo_artifact_dir().map(PathBuf::from);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn debug_artifacts(&self) -> &DebugArtifactRegistry {
+        &self.debug
+    }
+
+    #[cfg(test)]
+    pub(crate) fn register_debug_artifact(&mut self, kind: DebugArtifactKind, path: PathBuf) {
+        self.debug.register(kind, path);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cargo_source_elf(&self) -> Option<&Path> {
+        self.cargo.as_ref().map(|cargo| cargo.elf.as_path())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::{DebugArtifactKind, OutputArtifacts};
+
+    #[test]
+    fn debug_artifacts_do_not_change_runtime_image() {
+        let mut artifacts = OutputArtifacts::default();
+        artifacts.register_debug_artifact(
+            DebugArtifactKind::Disassembly,
+            PathBuf::from("/tmp/kernel.disassembly"),
+        );
+
+        assert!(artifacts.elf().is_none());
+        assert!(artifacts.bin().is_none());
+        assert!(artifacts.runtime_image().is_none());
+        assert_eq!(
+            artifacts
+                .debug_artifacts()
+                .get(DebugArtifactKind::Disassembly),
+            Some(Path::new("/tmp/kernel.disassembly"))
+        );
     }
 }

--- a/ostool/src/build/cargo_pipeline.rs
+++ b/ostool/src/build/cargo_pipeline.rs
@@ -73,6 +73,118 @@ impl CargoBuildOutcome {
     }
 }
 
+#[derive(Debug, Clone)]
+struct CargoBuildPlan {
+    command: String,
+    envs: Vec<(String, String)>,
+    extra_envs: Vec<(String, String)>,
+    extra_config_path: Option<PathBuf>,
+    package: String,
+    bin: Option<String>,
+    target: String,
+    target_dir: PathBuf,
+    features: Vec<String>,
+    config_args: Vec<String>,
+    someboot_args: Vec<String>,
+    release: bool,
+    message_format: &'static str,
+    extra_args: Vec<String>,
+}
+
+impl CargoBuildPlan {
+    fn render(&self, cargo_program: &Path, context: &ProcessContext) -> Command {
+        let mut cmd = crate::process::command(cargo_program.as_os_str(), context);
+        cmd.arg(&self.command);
+
+        for (key, value) in &self.envs {
+            println!("{}", format!("{key}={value}").cyan());
+            cmd.env(key, value);
+        }
+        for (key, value) in &self.extra_envs {
+            println!("{}", format!("{key}={value}").cyan());
+            cmd.env(key, value);
+        }
+
+        if let Some(extra_config_path) = &self.extra_config_path {
+            cmd.arg("--config");
+            cmd.arg(extra_config_path.display().to_string());
+        }
+
+        cmd.arg("-p");
+        cmd.arg(&self.package);
+        if let Some(bin) = &self.bin {
+            cmd.arg("--bin");
+            cmd.arg(bin);
+        }
+        cmd.arg("--target");
+        cmd.arg(&self.target);
+        cmd.arg("-Z");
+        cmd.arg("unstable-options");
+        cmd.arg("--target-dir");
+        cmd.arg(self.target_dir.display().to_string());
+
+        if !self.features.is_empty() {
+            cmd.arg("--features");
+            cmd.arg(self.features.join(","));
+        }
+
+        for arg in &self.config_args {
+            cmd.arg(arg);
+        }
+        for arg in &self.someboot_args {
+            cmd.arg(arg);
+        }
+
+        if self.release {
+            cmd.arg("--release");
+        }
+
+        cmd.arg("--message-format");
+        cmd.arg(self.message_format);
+
+        for arg in &self.extra_args {
+            cmd.arg(arg);
+        }
+
+        cmd
+    }
+
+    #[cfg(test)]
+    fn args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        args.push(self.command.clone());
+        if let Some(extra_config_path) = &self.extra_config_path {
+            args.push("--config".into());
+            args.push(extra_config_path.display().to_string());
+        }
+        args.push("-p".into());
+        args.push(self.package.clone());
+        if let Some(bin) = &self.bin {
+            args.push("--bin".into());
+            args.push(bin.clone());
+        }
+        args.push("--target".into());
+        args.push(self.target.clone());
+        args.push("-Z".into());
+        args.push("unstable-options".into());
+        args.push("--target-dir".into());
+        args.push(self.target_dir.display().to_string());
+        if !self.features.is_empty() {
+            args.push("--features".into());
+            args.push(self.features.join(","));
+        }
+        args.extend(self.config_args.clone());
+        args.extend(self.someboot_args.clone());
+        if self.release {
+            args.push("--release".into());
+        }
+        args.push("--message-format".into());
+        args.push(self.message_format.into());
+        args.extend(self.extra_args.clone());
+        args
+    }
+}
+
 /// A builder for constructing and executing Cargo commands.
 ///
 /// `CargoBuildPipeline` provides a fluent API for configuring Cargo build or run
@@ -229,60 +341,53 @@ impl<'a> CargoBuildPipeline<'a> {
     }
 
     async fn build_cargo_command(&mut self) -> anyhow::Result<Command> {
-        let mut cmd =
-            crate::process::command(self.cargo_program.as_os_str(), &self.input.process_context);
+        let plan = self.build_cargo_plan().await?;
+        Ok(plan.render(&self.cargo_program, &self.input.process_context))
+    }
 
-        cmd.arg(&self.command);
-
-        for (k, v) in &self.config.env {
-            println!("{}", format!("{k}={v}").cyan());
-            cmd.env(k, v);
-        }
-        for (k, v) in &self.extra_envs {
-            println!("{}", format!("{k}={v}").cyan());
-            cmd.env(k, v);
-        }
-
-        // Extra config
-        if let Some(extra_config_path) = self.cargo_extra_config().await? {
-            cmd.arg("--config");
-            cmd.arg(extra_config_path.display().to_string());
-        }
-
-        // Package and target
-        cmd.arg("-p");
-        cmd.arg(&self.config.package);
-        if let Some(bin) = &self.config.bin {
-            cmd.arg("--bin");
-            cmd.arg(bin);
-        }
-        cmd.arg("--target");
-        cmd.arg(&self.config.target);
-        cmd.arg("-Z");
-        cmd.arg("unstable-options");
-
-        cmd.arg("--target-dir");
-        cmd.arg(self.input.build_dir.display().to_string());
-
-        // Features
+    async fn build_cargo_plan(&mut self) -> anyhow::Result<CargoBuildPlan> {
         let features = self.build_features();
-        if !features.is_empty() {
-            cmd.arg("--features");
-            cmd.arg(features.join(","));
-        }
+        let extra_config_path = self.cargo_extra_config().await?;
+        let someboot_args = self.detect_someboot_args(&features)?;
+        let mut extra_envs = self
+            .extra_envs
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>();
+        extra_envs.sort_by(|left, right| left.0.cmp(&right.0));
+        let mut envs = self
+            .config
+            .env
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>();
+        envs.sort_by(|left, right| left.0.cmp(&right.0));
 
-        // Config args
-        for arg in &self.config.args {
-            cmd.arg(arg);
-        }
+        Ok(CargoBuildPlan {
+            command: self.command.clone(),
+            envs,
+            extra_envs,
+            extra_config_path,
+            package: self.config.package.clone(),
+            bin: self.config.bin.clone(),
+            target: self.config.target.clone(),
+            target_dir: self.input.build_dir.clone(),
+            features,
+            config_args: self.config.args.clone(),
+            someboot_args,
+            release: self.effective_profile() == CargoBuildProfile::Release,
+            message_format: "json-render-diagnostics",
+            extra_args: self.extra_args.clone(),
+        })
+    }
 
-        // Auto-detected args from someboot/build-info.toml
+    fn detect_someboot_args(&self, features: &[String]) -> anyhow::Result<Vec<String>> {
         let workspace_manifest = self.input.project_layout.workspace_dir().join("Cargo.toml");
         if self.input.enable_someboot_build_config && workspace_manifest.exists() {
-            let detected_args = someboot::detect_build_config_for_package(
+            someboot::detect_build_config_for_package(
                 &workspace_manifest,
                 &self.config.package,
-                &features,
+                features,
                 &self.config.target,
             )
             .with_context(|| {
@@ -290,26 +395,10 @@ impl<'a> CargoBuildPipeline<'a> {
                     "failed to detect someboot build config from {}",
                     workspace_manifest.display()
                 )
-            })?;
-            for arg in detected_args {
-                cmd.arg(arg);
-            }
+            })
+        } else {
+            Ok(Vec::new())
         }
-
-        // Release mode
-        if self.effective_profile() == CargoBuildProfile::Release {
-            cmd.arg("--release");
-        }
-
-        cmd.arg("--message-format");
-        cmd.arg("json-render-diagnostics");
-
-        // Extra args
-        for arg in &self.extra_args {
-            cmd.arg(arg);
-        }
-
-        Ok(cmd)
     }
 
     fn target_package_info(&self) -> anyhow::Result<(PackageId, Option<String>)> {
@@ -508,7 +597,7 @@ mod tests {
     use crate::{
         build::{
             cargo_pipeline::CargoBuildInput,
-            config::{Cargo, CargoBuildProfile},
+            config::{Cargo, CargoBuildProfile, LogLevel},
         },
         invocation::{Invocation, InvocationOptions},
         project::metadata,
@@ -541,6 +630,68 @@ mod tests {
         .unwrap();
     }
 
+    fn write_log_workspace(root: &Path, with_log_dependency: bool) {
+        fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\", \"log\"]\nresolver = \"3\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("app/src")).unwrap();
+        let dependency = if with_log_dependency {
+            "\n[dependencies]\nlog = { path = \"../log\" }\n"
+        } else {
+            ""
+        };
+        fs::write(
+            root.join("app/Cargo.toml"),
+            format!(
+                "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2024\"\n{dependency}"
+            ),
+        )
+        .unwrap();
+        fs::write(root.join("app/src/main.rs"), "fn main() {}\n").unwrap();
+        fs::create_dir_all(root.join("log/src")).unwrap();
+        fs::write(
+            root.join("log/Cargo.toml"),
+            "[package]\nname = \"log\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[features]\nmax_level_info = []\nrelease_max_level_info = []\n",
+        )
+        .unwrap();
+        fs::write(root.join("log/src/lib.rs"), "pub fn marker() {}\n").unwrap();
+    }
+
+    fn cargo_input_for(invocation: &Invocation, config: &Cargo, debug: bool) -> CargoBuildInput {
+        CargoBuildInput::new(
+            invocation.project_layout().clone(),
+            invocation.process_context().unwrap(),
+            invocation.build_dir(),
+            invocation
+                .state()
+                .build_config_path()
+                .map(std::path::Path::to_path_buf),
+            debug,
+            !config.disable_someboot_build_config,
+        )
+    }
+
+    async fn cargo_plan_args(root: &Path, config: &Cargo, debug: bool) -> Vec<String> {
+        let invocation = Invocation::new(InvocationOptions::new(
+            Some(root.to_path_buf()),
+            None,
+            None,
+            debug,
+        ))
+        .unwrap();
+        let input = cargo_input_for(&invocation, config, debug);
+        let mut builder = CargoBuildPipeline::build(input, config).skip_objcopy(true);
+        builder.build_cargo_plan().await.unwrap().args()
+    }
+
+    fn feature_arg(args: &[String]) -> Option<&str> {
+        args.windows(2)
+            .find(|window| window[0] == "--features")
+            .map(|window| window[1].as_str())
+    }
+
     #[tokio::test]
     async fn build_cargo_command_skips_someboot_args_when_cargo_config_disables_them() {
         let temp = tempfile::tempdir().unwrap();
@@ -561,17 +712,7 @@ mod tests {
             false,
         ))
         .unwrap();
-        let input = CargoBuildInput::new(
-            invocation.project_layout().clone(),
-            invocation.process_context().unwrap(),
-            invocation.build_dir(),
-            invocation
-                .state()
-                .build_config_path()
-                .map(std::path::Path::to_path_buf),
-            false,
-            !config.disable_someboot_build_config,
-        );
+        let input = cargo_input_for(&invocation, &config, false);
         let mut builder = CargoBuildPipeline::build(input, &config).skip_objcopy(true);
         let cmd = builder.build_cargo_command().await.unwrap();
         let args: Vec<String> = cmd
@@ -585,6 +726,124 @@ mod tests {
                 .iter()
                 .any(|arg| arg.contains("target.x86_64-unknown-none.rustflags"))
         );
+    }
+
+    #[tokio::test]
+    async fn build_cargo_plan_injects_someboot_args_once() {
+        let temp = tempfile::tempdir().unwrap();
+        write_someboot_workspace(temp.path());
+
+        let config = Cargo {
+            package: "app".into(),
+            target: "x86_64-unknown-none".into(),
+            profile: Some(CargoBuildProfile::Debug),
+            ..Default::default()
+        };
+
+        let args = cargo_plan_args(temp.path(), &config, false).await;
+
+        assert_eq!(
+            args.iter()
+                .filter(|arg| arg.as_str() == "--someboot-cargoarg")
+                .count(),
+            1
+        );
+        assert_eq!(
+            args.iter()
+                .filter(|arg| arg.contains("target.x86_64-unknown-none.rustflags"))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn build_cargo_plan_uses_debug_flag_as_default_profile() {
+        let temp = tempfile::tempdir().unwrap();
+        write_log_workspace(temp.path(), false);
+        let config = Cargo {
+            package: "app".into(),
+            target: "x86_64-unknown-none".into(),
+            ..Default::default()
+        };
+
+        let debug_args = cargo_plan_args(temp.path(), &config, true).await;
+        let release_args = cargo_plan_args(temp.path(), &config, false).await;
+
+        assert!(!debug_args.iter().any(|arg| arg == "--release"));
+        assert!(release_args.iter().any(|arg| arg == "--release"));
+    }
+
+    #[tokio::test]
+    async fn build_cargo_plan_profile_overrides_debug_flag() {
+        let temp = tempfile::tempdir().unwrap();
+        write_log_workspace(temp.path(), false);
+
+        let debug_profile = Cargo {
+            package: "app".into(),
+            target: "x86_64-unknown-none".into(),
+            profile: Some(CargoBuildProfile::Debug),
+            ..Default::default()
+        };
+        let release_profile = Cargo {
+            package: "app".into(),
+            target: "x86_64-unknown-none".into(),
+            profile: Some(CargoBuildProfile::Release),
+            ..Default::default()
+        };
+
+        let debug_args = cargo_plan_args(temp.path(), &debug_profile, false).await;
+        let release_args = cargo_plan_args(temp.path(), &release_profile, true).await;
+
+        assert!(!debug_args.iter().any(|arg| arg == "--release"));
+        assert!(release_args.iter().any(|arg| arg == "--release"));
+    }
+
+    #[tokio::test]
+    async fn build_cargo_plan_uses_effective_profile_for_log_feature() {
+        let temp = tempfile::tempdir().unwrap();
+        write_log_workspace(temp.path(), true);
+
+        let debug_config = Cargo {
+            package: "app".into(),
+            target: "x86_64-unknown-none".into(),
+            log: Some(LogLevel::Info),
+            profile: Some(CargoBuildProfile::Debug),
+            ..Default::default()
+        };
+        let release_config = Cargo {
+            package: "app".into(),
+            target: "x86_64-unknown-none".into(),
+            log: Some(LogLevel::Info),
+            profile: Some(CargoBuildProfile::Release),
+            ..Default::default()
+        };
+
+        let debug_args = cargo_plan_args(temp.path(), &debug_config, false).await;
+        let release_args = cargo_plan_args(temp.path(), &release_config, true).await;
+
+        assert_eq!(feature_arg(&debug_args), Some("log/max_level_info"));
+        assert_eq!(
+            feature_arg(&release_args),
+            Some("log/release_max_level_info")
+        );
+    }
+
+    #[tokio::test]
+    async fn build_cargo_plan_skips_log_feature_without_log_dependency() {
+        let temp = tempfile::tempdir().unwrap();
+        write_log_workspace(temp.path(), false);
+
+        let config = Cargo {
+            package: "app".into(),
+            target: "x86_64-unknown-none".into(),
+            log: Some(LogLevel::Info),
+            profile: Some(CargoBuildProfile::Debug),
+            ..Default::default()
+        };
+
+        let args = cargo_plan_args(temp.path(), &config, false).await;
+
+        assert!(feature_arg(&args).is_none());
     }
 
     #[tokio::test]
@@ -642,17 +901,7 @@ mod tests {
             fs::set_permissions(&cargo_bin, permissions).unwrap();
         }
 
-        let input = CargoBuildInput::new(
-            invocation.project_layout().clone(),
-            invocation.process_context().unwrap(),
-            invocation.build_dir(),
-            invocation
-                .state()
-                .build_config_path()
-                .map(std::path::Path::to_path_buf),
-            false,
-            !config.disable_someboot_build_config,
-        );
+        let input = cargo_input_for(&invocation, &config, false);
         let outcome = CargoBuildPipeline::build(input, &config)
             .skip_objcopy(true)
             .cargo_program(&cargo_bin)

--- a/ostool/src/build/mod.rs
+++ b/ostool/src/build/mod.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 use anyhow::bail;
 
 use crate::{
+    artifact::object_tools::ObjectTools,
     artifact::runtime::{
         RuntimeArtifactOptions, prepare_runtime_artifacts as prepare_runtime_artifact_outputs,
     },
@@ -405,7 +406,7 @@ fn apply_cargo_build_outcome(
             debug,
             cargo_artifact_dir: Some(resolved.cargo_artifact_dir().to_path_buf()),
             strip_elf: false,
-            objcopy_program: PathBuf::from("rust-objcopy"),
+            objcopy_program: ObjectTools.objcopy(),
         },
     )?;
     invocation.apply_prepared_runtime_artifacts(prepared);
@@ -436,6 +437,7 @@ mod tests {
 
     use super::{
         CargoSelector, activate_build_config, activate_build_context, apply_cargo_build_outcome,
+        build_with_config,
     };
 
     #[test]
@@ -486,10 +488,55 @@ mod tests {
             Some(cargo_artifact_dir.as_path())
         );
         assert_eq!(
+            invocation.runtime_artifacts().cargo_source_artifact_dir(),
+            Some(cargo_artifact_dir.as_path())
+        );
+        assert_eq!(
+            invocation.runtime_artifacts().cargo_source_elf(),
+            Some(expected_elf.as_path())
+        );
+        assert_eq!(
             invocation.runtime_artifacts().runtime_artifact_dir(),
             Some(cargo_artifact_dir.as_path())
         );
+        assert!(invocation.runtime_artifacts().debug_artifacts().is_empty());
         assert!(invocation.runtime_arch().is_some());
+    }
+
+    #[tokio::test]
+    async fn custom_build_only_does_not_prepare_runtime_artifacts() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"kernel\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(temp.path().join("src")).unwrap();
+        fs::write(temp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        let marker = temp.path().join("custom-build-ran");
+        let mut invocation = Invocation::new(InvocationOptions::new(
+            Some(temp.path().to_path_buf()),
+            None,
+            None,
+            false,
+        ))
+        .unwrap();
+        let config = BuildConfig {
+            system: BuildSystem::Custom(Custom {
+                build_cmd: format!("printf built > {}", marker.display()),
+                elf_path: "target/kernel.elf".into(),
+                to_bin: true,
+            }),
+        };
+
+        build_with_config(&mut invocation, &config, None)
+            .await
+            .unwrap();
+
+        assert_eq!(fs::read_to_string(marker).unwrap(), "built");
+        assert!(invocation.runtime_artifacts().elf().is_none());
+        assert!(invocation.runtime_artifacts().bin().is_none());
+        assert!(invocation.runtime_arch().is_none());
     }
 
     #[test]

--- a/ostool/src/invocation.rs
+++ b/ostool/src/invocation.rs
@@ -7,6 +7,7 @@ use object::Architecture;
 
 use crate::{
     artifact::{
+        object_tools::ObjectTools,
         runtime::{PreparedRuntimeArtifacts, RuntimeArtifactOptions, prepare_runtime_artifacts},
         state::OutputArtifacts,
     },
@@ -185,10 +186,10 @@ impl Invocation {
                 debug: self.options.debug(),
                 cargo_artifact_dir: self
                     .runtime_artifacts()
-                    .cargo_artifact_dir()
+                    .cargo_source_artifact_dir()
                     .map(PathBuf::from),
                 strip_elf: false,
-                objcopy_program: PathBuf::from("rust-objcopy"),
+                objcopy_program: ObjectTools.objcopy(),
             },
         )?;
         let bin_path = prepared
@@ -216,7 +217,7 @@ impl Invocation {
                 debug: self.options.debug(),
                 cargo_artifact_dir: None,
                 strip_elf: true,
-                objcopy_program: PathBuf::from("rust-objcopy"),
+                objcopy_program: ObjectTools.objcopy(),
             },
         )?;
         self.apply_prepared_runtime_artifacts(prepared);

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -824,8 +824,11 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::{
-        artifact::runtime::{RuntimeArtifactOptions, prepare_runtime_artifacts},
-        artifact::state::OutputArtifacts,
+        artifact::{
+            object_tools::ObjectTools,
+            runtime::{RuntimeArtifactOptions, prepare_runtime_artifacts},
+            state::OutputArtifacts,
+        },
         build::{
             config::{BuildConfig, BuildSystem, Cargo},
             config_loader,
@@ -1039,7 +1042,7 @@ fail_regex = []
                 debug: false,
                 cargo_artifact_dir: None,
                 strip_elf: false,
-                objcopy_program: PathBuf::from("rust-objcopy"),
+                objcopy_program: ObjectTools.objcopy(),
             },
         )
         .unwrap();


### PR DESCRIPTION
## 摘要

- 将 `OutputArtifacts` 内部拆分为 Cargo source、runtime artifact 和 debug artifact registry 三类状态，同时保留现有 runner-facing accessors。
- 新增 Rust object tools helper，并让现有 objcopy 调用和相关测试走统一入口。
- 引入 `CargoBuildPlan` 负责渲染 Cargo 命令，集中 someboot 自动参数检测与追加，避免后续构建阶段重复追加。
- 补充 custom build、Cargo artifact state、debug registry、someboot 注入和 profile/log feature 相关回归测试。

## 整体思路

这个 PR 是 #118 删除旧 `Tool` 兼容 API 后的后续内部重构切片。#118 已经把 public Rust API 收敛到 `Invocation` 与模块级 helper；本 PR 继续收窄 build/runtime 产物状态和 Cargo 命令构造边界，让后续 debug artifact pipeline 不需要复用 runtime `.bin` 字段或在多个阶段重复拼接 Cargo 参数。

一次构建现在可以更清楚地区分三类产物：Cargo JSON message 解析出的原始 executable artifact、runner 当前消费的 runtime ELF/BIN，以及后续调试产物使用的 registry。runner-facing accessor 保持不变，内部状态则避免继续用平铺字段同时表达 source、runtime 和 future debug outputs。

Cargo 命令构造也从直接拼接 `Command` 调整为先形成 `CargoBuildPlan` 再渲染。features、profile、log feature、extra config、someboot 自动参数和用户传入的额外 args 都在一个 plan 中收敛，减少后续添加 post-build 阶段时重复注入或顺序漂移的风险。

## 变更模块

- `ostool/src/artifact/state.rs`: 将 artifact state 内部拆成 Cargo source、runtime artifact 和 debug artifact registry，并保留既有 runtime accessor。
- `ostool/src/artifact/runtime.rs`: 区分 Cargo-reported source artifact dir 和非 Cargo/custom import 的 source artifact dir，保持旧 accessor 兼容语义。
- `ostool/src/artifact/object_tools.rs`: 新增 Rust toolchain object tools helper，统一 `rust-objcopy`、`rust-objdump`、`rust-readobj` 和 `rust-nm` 的定位入口。
- `ostool/src/build/cargo_pipeline.rs`: 引入 `CargoBuildPlan`，集中渲染 Cargo 命令并收敛 someboot 自动参数注入。
- `ostool/src/build/mod.rs`, `ostool/src/invocation.rs`, `ostool/src/run/qemu.rs`: 将现有 objcopy 调用和相关测试改为使用 object tools helper，并补充 artifact lifecycle 护栏测试。

## 兼容性

- 不新增 CLI 参数或配置字段。
- 不生成新的 debug artifacts。
- 不改变 Cargo executable selection 规则。
- 不改变 QEMU、U-Boot、TFTP、board runner 当前消费 runtime artifact 的对外语义。
- 新增类型和 helper 都保持 crate-private，不扩大 public Rust API。

## 验证

已运行并通过：

- `cargo fmt --all -- --check`
- `cargo test -p ostool`
- `cargo clippy -p ostool --all-targets --all-features -- -D warnings`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features -- -D warnings`
- `cargo build --target x86_64-unknown-linux-gnu --all-features`
- `cargo test --target x86_64-unknown-linux-gnu -- --nocapture`
- GitHub Actions `Quality Check`

## 风险 / 后续

- 本 PR 只预留 debug artifact registry 和 object tools 边界，不实现 `.disassembly`、`.elf_info` 或 symbol dump 等用户可见产物生成。
- 本 PR 只做 host-side Rust/CI 验证，没有实际启动 QEMU、U-Boot 或远程开发板 session。
- 后续 debug artifact pipeline 可以基于本 PR 的 registry/object tools 边界继续实现，但应作为独立用户可见功能 PR 处理。