### PR TITLE
refactor(tool): 抽出 U-Boot FIT 镜像生成边界

### DIFF
--- a/ostool/src/boot/fit.rs
+++ b/ostool/src/boot/fit.rs
@@ -1,0 +1,302 @@
+//! U-Boot FIT image generation.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use byte_unit::Byte;
+use fitimage::{ComponentConfig, FitImageBuilder, FitImageConfig};
+use log::{info, warn};
+use object::Architecture;
+use tokio::fs;
+
+use crate::utils::PathResultExt;
+
+const KERNEL_COMPONENT_NAME: &str = "kernel";
+const FDT_COMPONENT_NAME: &str = "fdt";
+const DEFAULT_CONFIG_NAME: &str = "config-ostool";
+const FIT_DESCRIPTION: &str = "Various kernels, ramdisks and FDT blobs";
+const FIT_IMAGE_NAME: &str = "image.fit";
+
+mod errors {
+    pub const KERNEL_READ_ERROR: &str = "读取 kernel 文件失败";
+    pub const DTB_READ_ERROR: &str = "读取 DTB 文件失败";
+    pub const FIT_BUILD_ERROR: &str = "构建 FIT image 失败";
+    pub const FIT_SAVE_ERROR: &str = "保存 FIT image 失败";
+    pub const DIR_ERROR: &str = "无法获取 kernel 文件目录";
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FitInput {
+    pub(crate) kernel_path: PathBuf,
+    pub(crate) dtb_path: Option<PathBuf>,
+    pub(crate) arch: Architecture,
+    pub(crate) kernel_load_addr: u64,
+    pub(crate) kernel_entry_addr: u64,
+    pub(crate) fdt_load_addr: Option<u64>,
+    pub(crate) output_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct GeneratedFitImage {
+    path: PathBuf,
+}
+
+impl GeneratedFitImage {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+pub(crate) async fn generate_fit_image(input: FitInput) -> anyhow::Result<GeneratedFitImage> {
+    info!("Making FIT image...");
+
+    let kernel_data = fs::read(&input.kernel_path)
+        .await
+        .with_path(errors::KERNEL_READ_ERROR, &input.kernel_path)?;
+
+    info!(
+        "kernel: {} (size: {:.2})",
+        input.kernel_path.display(),
+        Byte::from(kernel_data.len())
+    );
+
+    let arch_name = fit_arch_name(input.arch)?;
+    let dtb_data = if let Some(dtb_path) = &input.dtb_path {
+        let data = fs::read(dtb_path)
+            .await
+            .with_path(errors::DTB_READ_ERROR, dtb_path)?;
+        info!(
+            "已读取 DTB 文件: {} (大小: {:.2})",
+            dtb_path.display(),
+            Byte::from(data.len())
+        );
+        Some(data)
+    } else {
+        warn!("未指定 DTB 文件，将生成仅包含 kernel 的 FIT image");
+        None
+    };
+
+    let config = build_default_fit_config(
+        arch_name,
+        kernel_data,
+        dtb_data,
+        input.kernel_load_addr,
+        input.kernel_entry_addr,
+        input.fdt_load_addr,
+    );
+
+    let mut builder = FitImageBuilder::new();
+    let fit_data = builder
+        .build(config)
+        .with_context(|| errors::FIT_BUILD_ERROR.to_string())?;
+    let output_path = match input.output_path {
+        Some(path) => path,
+        None => default_output_path(&input.kernel_path)?,
+    };
+    fs::write(&output_path, fit_data)
+        .await
+        .with_path(errors::FIT_SAVE_ERROR, &output_path)?;
+
+    info!("FIT image ok: {}", output_path.display());
+    Ok(GeneratedFitImage { path: output_path })
+}
+
+pub(crate) fn fit_arch_name(arch: Architecture) -> anyhow::Result<&'static str> {
+    match arch {
+        Architecture::Aarch64 => Ok("arm64"),
+        Architecture::Arm => Ok("arm"),
+        Architecture::LoongArch64 => Ok("loongarch64"),
+        Architecture::Riscv64 => Ok("riscv"),
+        other => anyhow::bail!("unsupported architecture for FIT image generation: {other:?}"),
+    }
+}
+
+fn default_output_path(kernel_path: &Path) -> anyhow::Result<PathBuf> {
+    let output_dir = kernel_path
+        .parent()
+        .and_then(|p| p.to_str())
+        .ok_or_else(|| anyhow!("{}: {}", errors::DIR_ERROR, kernel_path.display()))?;
+    Ok(Path::new(output_dir).join(FIT_IMAGE_NAME))
+}
+
+fn build_default_fit_config(
+    arch_name: &'static str,
+    kernel_data: Vec<u8>,
+    dtb_data: Option<Vec<u8>>,
+    kernel_load_addr: u64,
+    kernel_entry_addr: u64,
+    fdt_load_addr: Option<u64>,
+) -> FitImageConfig {
+    let mut config = FitImageConfig::new(FIT_DESCRIPTION).with_kernel(
+        ComponentConfig::new(KERNEL_COMPONENT_NAME, kernel_data)
+            .with_description("This kernel")
+            .with_type("kernel")
+            .with_arch(arch_name)
+            .with_os("linux")
+            .with_compression(false)
+            .with_load_address(kernel_load_addr)
+            .with_entry_point(kernel_entry_addr),
+    );
+
+    let fdt_name = if let Some(data) = dtb_data {
+        let mut fdt_config = ComponentConfig::new(FDT_COMPONENT_NAME, data)
+            .with_description("This fdt")
+            .with_type("flat_dt")
+            .with_arch(arch_name);
+
+        if let Some(addr) = fdt_load_addr {
+            fdt_config = fdt_config.with_load_address(addr);
+        }
+
+        config = config.with_fdt(fdt_config);
+        Some(FDT_COMPONENT_NAME)
+    } else {
+        None
+    };
+
+    config
+        .with_default_config(DEFAULT_CONFIG_NAME)
+        .with_configuration(
+            DEFAULT_CONFIG_NAME,
+            "ostool configuration",
+            Some(KERNEL_COMPONENT_NAME),
+            fdt_name,
+            None::<String>,
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FitInput, build_default_fit_config, default_output_path, fit_arch_name};
+    use object::Architecture;
+
+    #[test]
+    fn maps_supported_architectures_to_fit_names() {
+        assert_eq!(fit_arch_name(Architecture::Aarch64).unwrap(), "arm64");
+        assert_eq!(fit_arch_name(Architecture::Arm).unwrap(), "arm");
+        assert_eq!(
+            fit_arch_name(Architecture::LoongArch64).unwrap(),
+            "loongarch64"
+        );
+        assert_eq!(fit_arch_name(Architecture::Riscv64).unwrap(), "riscv");
+    }
+
+    #[test]
+    fn rejects_unsupported_architecture_for_fit_generation() {
+        let err = fit_arch_name(Architecture::X86_64).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("unsupported architecture for FIT image generation: X86_64")
+        );
+    }
+
+    #[test]
+    fn default_output_path_uses_kernel_directory() {
+        let output_path = default_output_path(std::path::Path::new("/tmp/kernel.bin")).unwrap();
+
+        assert_eq!(output_path, std::path::Path::new("/tmp/image.fit"));
+    }
+
+    #[test]
+    fn default_fit_config_keeps_linux_kernel_defaults_without_dtb() {
+        let config = build_default_fit_config("arm64", vec![1, 2, 3], None, 0x80000, 0x80000, None);
+        let kernel = config.kernel.as_ref().unwrap();
+
+        assert_eq!(
+            config.description,
+            "Various kernels, ramdisks and FDT blobs"
+        );
+        assert_eq!(kernel.name, "kernel");
+        assert_eq!(kernel.component_type.as_deref(), Some("kernel"));
+        assert_eq!(kernel.arch.as_deref(), Some("arm64"));
+        assert_eq!(kernel.os.as_deref(), Some("linux"));
+        assert!(!kernel.compression);
+        assert_eq!(kernel.load_address, Some(0x80000));
+        assert_eq!(kernel.entry_point, Some(0x80000));
+        assert!(config.fdt.is_none());
+        assert_eq!(config.default_config.as_deref(), Some("config-ostool"));
+        let default_config = config.configurations.get("config-ostool").unwrap();
+        assert_eq!(default_config.kernel.as_deref(), Some("kernel"));
+        assert!(default_config.fdt.is_none());
+        assert!(default_config.ramdisk.is_none());
+    }
+
+    #[test]
+    fn default_fit_config_adds_optional_fdt_component() {
+        let config = build_default_fit_config(
+            "riscv",
+            vec![1, 2, 3],
+            Some(vec![4, 5, 6]),
+            0x8020_0000,
+            0x8020_0000,
+            Some(0x8800_0000),
+        );
+        let fdt = config.fdt.as_ref().unwrap();
+        let default_config = config.configurations.get("config-ostool").unwrap();
+
+        assert_eq!(fdt.name, "fdt");
+        assert_eq!(fdt.component_type.as_deref(), Some("flat_dt"));
+        assert_eq!(fdt.arch.as_deref(), Some("riscv"));
+        assert_eq!(fdt.load_address, Some(0x8800_0000));
+        assert_eq!(default_config.fdt.as_deref(), Some("fdt"));
+    }
+
+    #[tokio::test]
+    async fn generate_fit_image_writes_default_output_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let kernel_path = temp.path().join("kernel.bin");
+        tokio::fs::write(&kernel_path, [1_u8, 2, 3, 4])
+            .await
+            .unwrap();
+
+        let generated = super::generate_fit_image(FitInput {
+            kernel_path: kernel_path.clone(),
+            dtb_path: None,
+            arch: Architecture::Aarch64,
+            kernel_load_addr: 0x80000,
+            kernel_entry_addr: 0x80000,
+            fdt_load_addr: None,
+            output_path: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(generated.path(), temp.path().join("image.fit").as_path());
+        let fit_data = tokio::fs::read(generated.path()).await.unwrap();
+        assert!(fit_data.len() > 4);
+        assert_eq!(&fit_data[..4], &[0xd0, 0x0d, 0xfe, 0xed]);
+    }
+
+    #[tokio::test]
+    async fn generate_fit_image_reads_optional_dtb() {
+        let temp = tempfile::tempdir().unwrap();
+        let kernel_path = temp.path().join("kernel.bin");
+        let dtb_path = temp.path().join("board.dtb");
+        let output_path = temp.path().join("custom.fit");
+        tokio::fs::write(&kernel_path, [1_u8, 2, 3, 4])
+            .await
+            .unwrap();
+        tokio::fs::write(&dtb_path, [5_u8, 6, 7, 8]).await.unwrap();
+
+        let generated = super::generate_fit_image(FitInput {
+            kernel_path,
+            dtb_path: Some(dtb_path),
+            arch: Architecture::Riscv64,
+            kernel_load_addr: 0x8020_0000,
+            kernel_entry_addr: 0x8020_0000,
+            fdt_load_addr: Some(0x8800_0000),
+            output_path: Some(output_path.clone()),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(generated.path(), output_path.as_path());
+        assert!(
+            tokio::fs::metadata(generated.path())
+                .await
+                .unwrap()
+                .is_file()
+        );
+    }
+}

--- a/ostool/src/boot/mod.rs
+++ b/ostool/src/boot/mod.rs
@@ -1,0 +1,3 @@
+//! Boot artifact helpers.
+
+pub(crate) mod fit;

--- a/ostool/src/lib.rs
+++ b/ostool/src/lib.rs
@@ -33,6 +33,7 @@
 #![cfg(not(target_os = "none"))]
 
 mod artifact;
+mod boot;
 
 /// Build system configuration and Cargo integration.
 ///

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -7,11 +7,9 @@ use std::{
 
 use anyhow::Context;
 use async_trait::async_trait;
-use byte_unit::Byte;
 use colored::Colorize;
-use fitimage::{ComponentConfig, FitImageBuilder, FitImageConfig};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
-use log::{info, warn};
+use log::info;
 use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -40,6 +38,7 @@ use crate::{
             BoxedAsyncRead, BoxedAsyncWrite, SerialStreamTasks, connect_serial_stream,
         },
     },
+    boot::fit::{self, FitInput},
     invocation::Invocation,
     process::ProcessContext,
     project::variables::{self, VariableScope},
@@ -53,15 +52,6 @@ use crate::{
     sterm::{AsyncTerminal, TerminalConfig},
     utils::PathResultExt,
 };
-
-/// FIT image 生成相关的错误消息常量
-mod errors {
-    pub const KERNEL_READ_ERROR: &str = "读取 kernel 文件失败";
-    pub const DTB_READ_ERROR: &str = "读取 DTB 文件失败";
-    pub const FIT_BUILD_ERROR: &str = "构建 FIT image 失败";
-    pub const FIT_SAVE_ERROR: &str = "保存 FIT image 失败";
-    pub const DIR_ERROR: &str = "无法获取 kernel 文件目录";
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct UbootConfig {
@@ -1049,109 +1039,6 @@ where
         }
     }
 
-    /// 生成包含 kernel 和 FDT 的压缩 FIT image。
-    async fn generate_fit_image(
-        &self,
-        kernel_path: &Path,
-        dtb_path: Option<&Path>,
-        kernel_load_addr: u64,
-        kernel_entry_addr: u64,
-        fdt_load_addr: Option<u64>,
-        _ramfs_load_addr: Option<u64>,
-    ) -> anyhow::Result<PathBuf> {
-        info!("Making FIT image...");
-        // 生成压缩的 FIT image
-        let output_dir = kernel_path
-            .parent()
-            .and_then(|p| p.to_str())
-            .ok_or_else(|| anyhow!("{}: {}", errors::DIR_ERROR, kernel_path.display()))?;
-
-        // 读取 kernel 数据
-        let kernel_data = fs::read(kernel_path)
-            .await
-            .with_path(errors::KERNEL_READ_ERROR, kernel_path)?;
-
-        info!(
-            "kernel: {} (size: {:.2})",
-            kernel_path.display(),
-            Byte::from(kernel_data.len())
-        );
-
-        let arch = self
-            .input
-            .arch
-            .ok_or_else(|| anyhow!("Cannot determine architecture for FIT image generation"))?;
-        let arch = match arch {
-            object::Architecture::Aarch64 => "arm64",
-            object::Architecture::Arm => "arm",
-            object::Architecture::LoongArch64 => "loongarch64",
-            object::Architecture::Riscv64 => "riscv",
-            other => anyhow::bail!("unsupported architecture for FIT image generation: {other:?}"),
-        };
-
-        let mut config = FitImageConfig::new("Various kernels, ramdisks and FDT blobs")
-            .with_kernel(
-                ComponentConfig::new("kernel", kernel_data)
-                    .with_description("This kernel")
-                    .with_type("kernel")
-                    .with_arch(arch)
-                    .with_os("linux")
-                    .with_compression(false)
-                    .with_load_address(kernel_load_addr)
-                    .with_entry_point(kernel_entry_addr),
-            );
-        let mut fdt_name = None;
-
-        // 处理 DTB 文件
-        if let Some(dtb_path) = dtb_path {
-            let data = fs::read(dtb_path)
-                .await
-                .with_path(errors::DTB_READ_ERROR, dtb_path)?;
-            info!(
-                "已读取 DTB 文件: {} (大小: {:.2})",
-                dtb_path.display(),
-                Byte::from(data.len())
-            );
-            fdt_name = Some("fdt");
-
-            // U-Boot 不接受压缩的 DTB
-            let mut fdt_config = ComponentConfig::new("fdt", data.clone())
-                .with_description("This fdt")
-                .with_type("flat_dt")
-                .with_arch(arch);
-
-            if let Some(addr) = fdt_load_addr {
-                fdt_config = fdt_config.with_load_address(addr);
-            }
-
-            config = config.with_fdt(fdt_config);
-        } else {
-            warn!("未指定 DTB 文件，将生成仅包含 kernel 的 FIT image");
-        }
-
-        config = config
-            .with_default_config("config-ostool")
-            .with_configuration(
-                "config-ostool",
-                "ostool configuration",
-                Some("kernel"),
-                fdt_name,
-                None::<String>,
-            );
-
-        let mut builder = FitImageBuilder::new();
-        let fit_data = builder
-            .build(config)
-            .with_context(|| errors::FIT_BUILD_ERROR.to_string())?;
-        let output_path = Path::new(output_dir).join("image.fit");
-        fs::write(&output_path, fit_data)
-            .await
-            .with_path(errors::FIT_SAVE_ERROR, &output_path)?;
-
-        info!("FIT image ok: {}", output_path.display());
-        Ok(output_path)
-    }
-
     async fn run(&mut self) -> anyhow::Result<()> {
         let run_result = self._run().await;
 
@@ -1240,15 +1127,11 @@ where
         }
 
         let mut fdt_load_addr = None;
-        let mut ramfs_load_addr = None;
-
         if let Ok(addr) = uboot.env_int("fdt_addr_r").await {
             fdt_load_addr = Some(addr as u64);
         }
 
-        if let Ok(addr) = uboot.env_int("ramdisk_addr_r").await {
-            ramfs_load_addr = Some(addr as u64);
-        }
+        let _ramfs_load_addr = uboot.env_int("ramdisk_addr_r").await.ok();
 
         let kernel_entry = if let Some(entry) = self
             .config
@@ -1292,18 +1175,25 @@ where
         if let Some(ref dtb_path) = prepared_dtb.fit_source {
             info!("Using DTB from: {}", dtb_path.display());
         }
-        let fitimage = self
-            .generate_fit_image(
-                &kernel,
-                prepared_dtb.fit_source.as_deref(),
-                kernel_entry,
-                kernel_entry,
-                fdt_load_addr,
-                ramfs_load_addr,
-            )
-            .await?;
+        let arch = self
+            .input
+            .arch
+            .ok_or_else(|| anyhow!("Cannot determine architecture for FIT image generation"))?;
+        let generated_fit = fit::generate_fit_image(FitInput {
+            kernel_path: kernel.clone(),
+            dtb_path: prepared_dtb.fit_source.clone(),
+            arch,
+            kernel_load_addr: kernel_entry,
+            kernel_entry_addr: kernel_entry,
+            fdt_load_addr,
+            output_path: None,
+        })
+        .await?;
 
-        let prepared = self.backend.stage_fit_image(&fitimage, &runtime).await?;
+        let prepared = self
+            .backend
+            .stage_fit_image(generated_fit.path(), &runtime)
+            .await?;
 
         let bootm_arg = self.resolved_bootm_arg(fit_loadaddr, &runtime);
         let bootcmd = if let Some(fitname) = prepared.bootfile.as_deref() {
@@ -1318,12 +1208,12 @@ where
                 request.bootcmd
             } else {
                 info!("No network boot request available, using loady to upload FIT image...");
-                Self::uboot_loady(&mut uboot, fit_loadaddr as usize, fitimage).await?;
+                Self::uboot_loady(&mut uboot, fit_loadaddr as usize, generated_fit.path()).await?;
                 self.serial_bootm_command(bootm_arg)
             }
         } else {
             info!("No TFTP config, using loady to upload FIT image...");
-            Self::uboot_loady(&mut uboot, fit_loadaddr as usize, fitimage).await?;
+            Self::uboot_loady(&mut uboot, fit_loadaddr as usize, generated_fit.path()).await?;
             self.serial_bootm_command(bootm_arg)
         };
 


### PR DESCRIPTION
## 摘要

- 新增 crate-private `boot::fit` 模块，集中处理 U-Boot FIT image 生成。
- 将 FIT arch 映射、默认 `image.fit` 输出路径、默认 Linux kernel/FDT 配置和 FIT 写文件逻辑移出 U-Boot runner。
- 让 U-Boot runner 只负责解析地址、构造 `FitInput`、stage 生成的 FIT image，并继续执行现有 `bootm` / `loady` 流程。
- 补充 FIT generator 单元测试，覆盖 arch 映射、unsupported arch、默认输出路径、默认 FIT 配置和可选 DTB 输入。

## 整体思路

这个 PR 是 #119 artifact lifecycle 边界之后的后续内部重构切片。#119 已经把 build/runtime 产物状态收敛为更清晰的内部生命周期；本 PR 继续收窄 U-Boot runner 中的 FIT 生成职责，让 FIT construction 可以脱离 runner staging、U-Boot shell state 和 board backend 独立测试。

原来的 U-Boot runner 同时负责读取 U-Boot 环境、推导 load/entry 地址、构造 `fitimage` 配置、写出 FIT 文件、stage FIT 文件并执行启动命令。本 PR 把其中可独立测试的 FIT construction 移到 `boot::fit`，runner 主流程只保留启动阶段真正需要的 orchestration。

默认行为保持不变：未显式指定输出路径时仍写入 kernel artifact 目录下的 `image.fit`，默认 kernel component 仍使用 `type = "kernel"`、`os = "linux"`、uncompressed kernel，DTB 仍是可选 FDT component，默认 configuration 仍是 `config-ostool`。

## 变更模块

- `ostool/src/boot/fit.rs`: 新增 FIT generator、`FitInput`、`GeneratedFitImage`、arch mapping、默认输出路径和默认 FIT config 构造逻辑。
- `ostool/src/boot/mod.rs`, `ostool/src/lib.rs`: 接入 crate-private boot helper module，不新增 public Rust API。
- `ostool/src/run/uboot.rs`: 删除直接 `fitimage` 构造逻辑，改为解析地址后调用 `boot::fit::generate_fit_image()`，并保留现有 staging、TFTP/YMODEM、remote board 和 `bootm` 行为。

## 兼容性

- 不新增 CLI 参数或配置字段。
- 不改变 `.uboot.toml` / `.board.toml` 语义。
- 不改变默认 FIT 输出路径、kernel/FDT component 默认值或 unsupported architecture 错误语义。
- 不改变 TFTP、YMODEM、remote board session、serial console、matcher、timeout 或 `bootm` 行为。
- 新增类型和 helper 都保持 crate-private，不扩大 public Rust API。

## 验证

已运行并通过：

- `cargo fmt --all -- --check`
- `cargo test -p ostool`
- `cargo clippy -p ostool --all-targets --all-features -- -D warnings`
- `git diff --check`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features -- -D warnings`
- `cargo build --target x86_64-unknown-linux-gnu --all-features`
- `cargo test --target x86_64-unknown-linux-gnu -- --nocapture`

## 风险 / 后续

- 本 PR 只抽出 FIT generator 边界，不新增用户可见 FIT 配置。
- 本 PR 保持现有 Linux kernel FIT 默认语义；后续如需支持 `os = "elf"`、自定义 component 或多 configuration，应作为独立功能 PR 处理。
- 本 PR 只做 host-side Rust/CI target 验证，没有实际启动 U-Boot 串口或远程开发板 session。
