### PR TITLE
refactor(tool): 抽出 U-Boot FIT 与 boot artifact 边界

### DIFF
--- a/ostool/src/boot/artifacts.rs
+++ b/ostool/src/boot/artifacts.rs
@@ -1,0 +1,174 @@
+//! Boot artifact staging value types.
+
+use std::{
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
+use tokio::fs;
+
+use crate::utils::PathResultExt;
+
+const QEMU_DTB_DUMP_PATH: &str = "target/qemu.dtb";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BootArtifactKind {
+    QemuDtbDump,
+    FitImage,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BootArtifact {
+    kind: BootArtifactKind,
+    path: PathBuf,
+}
+
+impl BootArtifact {
+    pub(crate) fn qemu_dtb_dump(path: impl Into<PathBuf>) -> Self {
+        Self {
+            kind: BootArtifactKind::QemuDtbDump,
+            path: path.into(),
+        }
+    }
+
+    pub(crate) fn fit_image(path: impl Into<PathBuf>) -> Self {
+        Self {
+            kind: BootArtifactKind::FitImage,
+            path: path.into(),
+        }
+    }
+
+    pub(crate) fn kind(&self) -> BootArtifactKind {
+        self.kind
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct QemuDtbDumpArtifact {
+    artifact: BootArtifact,
+}
+
+impl QemuDtbDumpArtifact {
+    fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            artifact: BootArtifact::qemu_dtb_dump(path),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        self.artifact.path()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StagedBootArtifact {
+    bootfile: Option<String>,
+    network_transfer_ready: bool,
+}
+
+impl StagedBootArtifact {
+    pub(crate) fn network(bootfile: impl Into<String>) -> Self {
+        Self {
+            bootfile: Some(bootfile.into()),
+            network_transfer_ready: true,
+        }
+    }
+
+    pub(crate) fn no_network() -> Self {
+        Self {
+            bootfile: None,
+            network_transfer_ready: false,
+        }
+    }
+
+    pub(crate) fn bootfile(&self) -> Option<&str> {
+        self.bootfile.as_deref()
+    }
+
+    pub(crate) fn network_transfer_ready(&self) -> bool {
+        self.network_transfer_ready
+    }
+}
+
+pub(crate) fn default_qemu_dtb_dump_path() -> PathBuf {
+    PathBuf::from(QEMU_DTB_DUMP_PATH)
+}
+
+pub(crate) async fn prepare_qemu_dtb_dump(
+    output_path: impl Into<PathBuf>,
+) -> anyhow::Result<QemuDtbDumpArtifact> {
+    let output_path = output_path.into();
+    if let Err(err) = fs::remove_file(&output_path).await
+        && err.kind() != ErrorKind::NotFound
+    {
+        return Err(err).with_path("failed to remove file", &output_path);
+    }
+
+    Ok(QemuDtbDumpArtifact::new(output_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BootArtifact, BootArtifactKind, StagedBootArtifact, default_qemu_dtb_dump_path,
+        prepare_qemu_dtb_dump,
+    };
+
+    #[test]
+    fn boot_artifact_keeps_kind_and_path() {
+        let fit = BootArtifact::fit_image("/tmp/image.fit");
+        let dtb = BootArtifact::qemu_dtb_dump("target/qemu.dtb");
+
+        assert_eq!(fit.kind(), BootArtifactKind::FitImage);
+        assert_eq!(fit.path(), std::path::Path::new("/tmp/image.fit"));
+        assert_eq!(dtb.kind(), BootArtifactKind::QemuDtbDump);
+        assert_eq!(dtb.path(), std::path::Path::new("target/qemu.dtb"));
+    }
+
+    #[test]
+    fn staged_boot_artifact_describes_network_transfer() {
+        let network = StagedBootArtifact::network("image.fit");
+        let no_network = StagedBootArtifact::no_network();
+
+        assert_eq!(network.bootfile(), Some("image.fit"));
+        assert!(network.network_transfer_ready());
+        assert_eq!(no_network.bootfile(), None);
+        assert!(!no_network.network_transfer_ready());
+    }
+
+    #[test]
+    fn default_qemu_dtb_dump_path_matches_existing_contract() {
+        assert_eq!(
+            default_qemu_dtb_dump_path(),
+            std::path::Path::new("target/qemu.dtb")
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_qemu_dtb_dump_removes_existing_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("qemu.dtb");
+        tokio::fs::write(&path, [1_u8, 2, 3]).await.unwrap();
+
+        let artifact = prepare_qemu_dtb_dump(path.clone()).await.unwrap();
+
+        assert_eq!(artifact.path(), path.as_path());
+        assert_eq!(artifact.artifact.kind(), BootArtifactKind::QemuDtbDump);
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn prepare_qemu_dtb_dump_ignores_missing_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("missing.dtb");
+
+        let artifact = prepare_qemu_dtb_dump(path.clone()).await.unwrap();
+
+        assert_eq!(artifact.path(), path.as_path());
+        assert!(!path.exists());
+    }
+}

--- a/ostool/src/boot/fit.rs
+++ b/ostool/src/boot/fit.rs
@@ -1,0 +1,302 @@
+//! U-Boot FIT image generation.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use byte_unit::Byte;
+use fitimage::{ComponentConfig, FitImageBuilder, FitImageConfig};
+use log::{info, warn};
+use object::Architecture;
+use tokio::fs;
+
+use crate::utils::PathResultExt;
+
+const KERNEL_COMPONENT_NAME: &str = "kernel";
+const FDT_COMPONENT_NAME: &str = "fdt";
+const DEFAULT_CONFIG_NAME: &str = "config-ostool";
+const FIT_DESCRIPTION: &str = "Various kernels, ramdisks and FDT blobs";
+const FIT_IMAGE_NAME: &str = "image.fit";
+
+mod errors {
+    pub const KERNEL_READ_ERROR: &str = "读取 kernel 文件失败";
+    pub const DTB_READ_ERROR: &str = "读取 DTB 文件失败";
+    pub const FIT_BUILD_ERROR: &str = "构建 FIT image 失败";
+    pub const FIT_SAVE_ERROR: &str = "保存 FIT image 失败";
+    pub const DIR_ERROR: &str = "无法获取 kernel 文件目录";
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FitInput {
+    pub(crate) kernel_path: PathBuf,
+    pub(crate) dtb_path: Option<PathBuf>,
+    pub(crate) arch: Architecture,
+    pub(crate) kernel_load_addr: u64,
+    pub(crate) kernel_entry_addr: u64,
+    pub(crate) fdt_load_addr: Option<u64>,
+    pub(crate) output_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct GeneratedFitImage {
+    path: PathBuf,
+}
+
+impl GeneratedFitImage {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+pub(crate) async fn generate_fit_image(input: FitInput) -> anyhow::Result<GeneratedFitImage> {
+    info!("Making FIT image...");
+
+    let kernel_data = fs::read(&input.kernel_path)
+        .await
+        .with_path(errors::KERNEL_READ_ERROR, &input.kernel_path)?;
+
+    info!(
+        "kernel: {} (size: {:.2})",
+        input.kernel_path.display(),
+        Byte::from(kernel_data.len())
+    );
+
+    let arch_name = fit_arch_name(input.arch)?;
+    let dtb_data = if let Some(dtb_path) = &input.dtb_path {
+        let data = fs::read(dtb_path)
+            .await
+            .with_path(errors::DTB_READ_ERROR, dtb_path)?;
+        info!(
+            "已读取 DTB 文件: {} (大小: {:.2})",
+            dtb_path.display(),
+            Byte::from(data.len())
+        );
+        Some(data)
+    } else {
+        warn!("未指定 DTB 文件，将生成仅包含 kernel 的 FIT image");
+        None
+    };
+
+    let config = build_default_fit_config(
+        arch_name,
+        kernel_data,
+        dtb_data,
+        input.kernel_load_addr,
+        input.kernel_entry_addr,
+        input.fdt_load_addr,
+    );
+
+    let mut builder = FitImageBuilder::new();
+    let fit_data = builder
+        .build(config)
+        .with_context(|| errors::FIT_BUILD_ERROR.to_string())?;
+    let output_path = match input.output_path {
+        Some(path) => path,
+        None => default_output_path(&input.kernel_path)?,
+    };
+    fs::write(&output_path, fit_data)
+        .await
+        .with_path(errors::FIT_SAVE_ERROR, &output_path)?;
+
+    info!("FIT image ok: {}", output_path.display());
+    Ok(GeneratedFitImage { path: output_path })
+}
+
+pub(crate) fn fit_arch_name(arch: Architecture) -> anyhow::Result<&'static str> {
+    match arch {
+        Architecture::Aarch64 => Ok("arm64"),
+        Architecture::Arm => Ok("arm"),
+        Architecture::LoongArch64 => Ok("loongarch64"),
+        Architecture::Riscv64 => Ok("riscv"),
+        other => anyhow::bail!("unsupported architecture for FIT image generation: {other:?}"),
+    }
+}
+
+fn default_output_path(kernel_path: &Path) -> anyhow::Result<PathBuf> {
+    let output_dir = kernel_path
+        .parent()
+        .and_then(|p| p.to_str())
+        .ok_or_else(|| anyhow!("{}: {}", errors::DIR_ERROR, kernel_path.display()))?;
+    Ok(Path::new(output_dir).join(FIT_IMAGE_NAME))
+}
+
+fn build_default_fit_config(
+    arch_name: &'static str,
+    kernel_data: Vec<u8>,
+    dtb_data: Option<Vec<u8>>,
+    kernel_load_addr: u64,
+    kernel_entry_addr: u64,
+    fdt_load_addr: Option<u64>,
+) -> FitImageConfig {
+    let mut config = FitImageConfig::new(FIT_DESCRIPTION).with_kernel(
+        ComponentConfig::new(KERNEL_COMPONENT_NAME, kernel_data)
+            .with_description("This kernel")
+            .with_type("kernel")
+            .with_arch(arch_name)
+            .with_os("linux")
+            .with_compression(false)
+            .with_load_address(kernel_load_addr)
+            .with_entry_point(kernel_entry_addr),
+    );
+
+    let fdt_name = if let Some(data) = dtb_data {
+        let mut fdt_config = ComponentConfig::new(FDT_COMPONENT_NAME, data)
+            .with_description("This fdt")
+            .with_type("flat_dt")
+            .with_arch(arch_name);
+
+        if let Some(addr) = fdt_load_addr {
+            fdt_config = fdt_config.with_load_address(addr);
+        }
+
+        config = config.with_fdt(fdt_config);
+        Some(FDT_COMPONENT_NAME)
+    } else {
+        None
+    };
+
+    config
+        .with_default_config(DEFAULT_CONFIG_NAME)
+        .with_configuration(
+            DEFAULT_CONFIG_NAME,
+            "ostool configuration",
+            Some(KERNEL_COMPONENT_NAME),
+            fdt_name,
+            None::<String>,
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FitInput, build_default_fit_config, default_output_path, fit_arch_name};
+    use object::Architecture;
+
+    #[test]
+    fn maps_supported_architectures_to_fit_names() {
+        assert_eq!(fit_arch_name(Architecture::Aarch64).unwrap(), "arm64");
+        assert_eq!(fit_arch_name(Architecture::Arm).unwrap(), "arm");
+        assert_eq!(
+            fit_arch_name(Architecture::LoongArch64).unwrap(),
+            "loongarch64"
+        );
+        assert_eq!(fit_arch_name(Architecture::Riscv64).unwrap(), "riscv");
+    }
+
+    #[test]
+    fn rejects_unsupported_architecture_for_fit_generation() {
+        let err = fit_arch_name(Architecture::X86_64).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("unsupported architecture for FIT image generation: X86_64")
+        );
+    }
+
+    #[test]
+    fn default_output_path_uses_kernel_directory() {
+        let output_path = default_output_path(std::path::Path::new("/tmp/kernel.bin")).unwrap();
+
+        assert_eq!(output_path, std::path::Path::new("/tmp/image.fit"));
+    }
+
+    #[test]
+    fn default_fit_config_keeps_linux_kernel_defaults_without_dtb() {
+        let config = build_default_fit_config("arm64", vec![1, 2, 3], None, 0x80000, 0x80000, None);
+        let kernel = config.kernel.as_ref().unwrap();
+
+        assert_eq!(
+            config.description,
+            "Various kernels, ramdisks and FDT blobs"
+        );
+        assert_eq!(kernel.name, "kernel");
+        assert_eq!(kernel.component_type.as_deref(), Some("kernel"));
+        assert_eq!(kernel.arch.as_deref(), Some("arm64"));
+        assert_eq!(kernel.os.as_deref(), Some("linux"));
+        assert!(!kernel.compression);
+        assert_eq!(kernel.load_address, Some(0x80000));
+        assert_eq!(kernel.entry_point, Some(0x80000));
+        assert!(config.fdt.is_none());
+        assert_eq!(config.default_config.as_deref(), Some("config-ostool"));
+        let default_config = config.configurations.get("config-ostool").unwrap();
+        assert_eq!(default_config.kernel.as_deref(), Some("kernel"));
+        assert!(default_config.fdt.is_none());
+        assert!(default_config.ramdisk.is_none());
+    }
+
+    #[test]
+    fn default_fit_config_adds_optional_fdt_component() {
+        let config = build_default_fit_config(
+            "riscv",
+            vec![1, 2, 3],
+            Some(vec![4, 5, 6]),
+            0x8020_0000,
+            0x8020_0000,
+            Some(0x8800_0000),
+        );
+        let fdt = config.fdt.as_ref().unwrap();
+        let default_config = config.configurations.get("config-ostool").unwrap();
+
+        assert_eq!(fdt.name, "fdt");
+        assert_eq!(fdt.component_type.as_deref(), Some("flat_dt"));
+        assert_eq!(fdt.arch.as_deref(), Some("riscv"));
+        assert_eq!(fdt.load_address, Some(0x8800_0000));
+        assert_eq!(default_config.fdt.as_deref(), Some("fdt"));
+    }
+
+    #[tokio::test]
+    async fn generate_fit_image_writes_default_output_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let kernel_path = temp.path().join("kernel.bin");
+        tokio::fs::write(&kernel_path, [1_u8, 2, 3, 4])
+            .await
+            .unwrap();
+
+        let generated = super::generate_fit_image(FitInput {
+            kernel_path: kernel_path.clone(),
+            dtb_path: None,
+            arch: Architecture::Aarch64,
+            kernel_load_addr: 0x80000,
+            kernel_entry_addr: 0x80000,
+            fdt_load_addr: None,
+            output_path: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(generated.path(), temp.path().join("image.fit").as_path());
+        let fit_data = tokio::fs::read(generated.path()).await.unwrap();
+        assert!(fit_data.len() > 4);
+        assert_eq!(&fit_data[..4], &[0xd0, 0x0d, 0xfe, 0xed]);
+    }
+
+    #[tokio::test]
+    async fn generate_fit_image_reads_optional_dtb() {
+        let temp = tempfile::tempdir().unwrap();
+        let kernel_path = temp.path().join("kernel.bin");
+        let dtb_path = temp.path().join("board.dtb");
+        let output_path = temp.path().join("custom.fit");
+        tokio::fs::write(&kernel_path, [1_u8, 2, 3, 4])
+            .await
+            .unwrap();
+        tokio::fs::write(&dtb_path, [5_u8, 6, 7, 8]).await.unwrap();
+
+        let generated = super::generate_fit_image(FitInput {
+            kernel_path,
+            dtb_path: Some(dtb_path),
+            arch: Architecture::Riscv64,
+            kernel_load_addr: 0x8020_0000,
+            kernel_entry_addr: 0x8020_0000,
+            fdt_load_addr: Some(0x8800_0000),
+            output_path: Some(output_path.clone()),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(generated.path(), output_path.as_path());
+        assert!(
+            tokio::fs::metadata(generated.path())
+                .await
+                .unwrap()
+                .is_file()
+        );
+    }
+}

--- a/ostool/src/boot/mod.rs
+++ b/ostool/src/boot/mod.rs
@@ -1,0 +1,3 @@
+//! Boot artifact helpers.
+
+pub(crate) mod fit;

--- a/ostool/src/boot/mod.rs
+++ b/ostool/src/boot/mod.rs
@@ -1,3 +1,4 @@
 //! Boot artifact helpers.
 
+pub(crate) mod artifacts;
 pub(crate) mod fit;

--- a/ostool/src/lib.rs
+++ b/ostool/src/lib.rs
@@ -33,6 +33,7 @@
 #![cfg(not(target_os = "none"))]
 
 mod artifact;
+mod boot;
 
 /// Build system configuration and Cargo integration.
 ///

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -45,6 +45,7 @@ use tokio::{
 
 use crate::{
     artifact::state::OutputArtifacts,
+    boot::artifacts::{default_qemu_dtb_dump_path, prepare_qemu_dtb_dump},
     build::config::Cargo,
     invocation::Invocation,
     process::ProcessContext,
@@ -449,14 +450,9 @@ impl QemuRunner {
         }
 
         if self.dtbdump {
-            let dtb_dump_path = PathBuf::from("target/qemu.dtb");
-            if let Err(err) = fs::remove_file(&dtb_dump_path).await
-                && err.kind() != ErrorKind::NotFound
-            {
-                return Err(err).with_path("failed to remove file", &dtb_dump_path);
-            }
+            let dtb_dump = prepare_qemu_dtb_dump(default_qemu_dtb_dump_path()).await?;
             cmd.arg("-machine")
-                .arg(format!("dumpdtb={}", dtb_dump_path.display()));
+                .arg(format!("dumpdtb={}", dtb_dump.path().display()));
             // machine = format!("{},dumpdtb=target/qemu.dtb", machine);
         }
 

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use async_trait::async_trait;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
@@ -38,7 +38,10 @@ use crate::{
             BoxedAsyncRead, BoxedAsyncWrite, SerialStreamTasks, connect_serial_stream,
         },
     },
-    boot::fit::{self, FitInput},
+    boot::{
+        artifacts::{BootArtifact, BootArtifactKind, StagedBootArtifact},
+        fit::{self, FitInput},
+    },
     invocation::Invocation,
     process::ProcessContext,
     project::variables::{self, VariableScope},
@@ -500,11 +503,6 @@ struct ResolvedRuntime {
     use_tftp: bool,
 }
 
-struct PreparedBootArtifact {
-    bootfile: Option<String>,
-    network_transfer_ready: bool,
-}
-
 #[derive(Debug, Clone, Default)]
 struct PreparedDtb {
     fit_source: Option<PathBuf>,
@@ -526,9 +524,9 @@ trait RunnerBackend {
     async fn after_console_open(&mut self, context: &ProcessContext) -> anyhow::Result<()>;
     async fn stage_fit_image(
         &mut self,
-        fitimage: &Path,
+        fit_artifact: &BootArtifact,
         runtime: &ResolvedRuntime,
-    ) -> anyhow::Result<PreparedBootArtifact>;
+    ) -> anyhow::Result<StagedBootArtifact>;
     async fn finish_console(&mut self) -> anyhow::Result<()>;
     async fn after_run(&mut self, context: &ProcessContext) -> anyhow::Result<()>;
 }
@@ -698,9 +696,10 @@ impl RunnerBackend for LocalBackend {
 
     async fn stage_fit_image(
         &mut self,
-        fitimage: &Path,
+        fit_artifact: &BootArtifact,
         _runtime: &ResolvedRuntime,
-    ) -> anyhow::Result<PreparedBootArtifact> {
+    ) -> anyhow::Result<StagedBootArtifact> {
+        let fitimage = fit_artifact_path(fit_artifact)?;
         let Some(file_name) = fitimage.file_name().and_then(|name| name.to_str()) else {
             return Err(anyhow!("Invalid fitimage filename"));
         };
@@ -713,34 +712,22 @@ impl RunnerBackend for LocalBackend {
                     "Staged FIT image to: {}",
                     prepared.absolute_fit_path.display()
                 );
-                return Ok(PreparedBootArtifact {
-                    bootfile: Some(prepared.relative_filename),
-                    network_transfer_ready: true,
-                });
+                return Ok(StagedBootArtifact::network(prepared.relative_filename));
             }
         }
 
         if let Some(tftp_dir) = self.existing_tftp_dir.as_deref() {
             let tftp_path = PathBuf::from(tftp_dir).join(file_name);
             info!("Setting TFTP file path: {}", tftp_path.display());
-            return Ok(PreparedBootArtifact {
-                bootfile: Some(tftp_path.display().to_string()),
-                network_transfer_ready: true,
-            });
+            return Ok(StagedBootArtifact::network(tftp_path.display().to_string()));
         }
 
         if self.builtin_tftp_started {
             info!("Using fitimage filename: {}", file_name);
-            return Ok(PreparedBootArtifact {
-                bootfile: Some(file_name.to_string()),
-                network_transfer_ready: true,
-            });
+            return Ok(StagedBootArtifact::network(file_name));
         }
 
-        Ok(PreparedBootArtifact {
-            bootfile: None,
-            network_transfer_ready: false,
-        })
+        Ok(StagedBootArtifact::no_network())
     }
 
     async fn finish_console(&mut self) -> anyhow::Result<()> {
@@ -974,18 +961,16 @@ impl RunnerBackend for RemoteBackend {
 
     async fn stage_fit_image(
         &mut self,
-        fitimage: &Path,
+        fit_artifact: &BootArtifact,
         runtime: &ResolvedRuntime,
-    ) -> anyhow::Result<PreparedBootArtifact> {
+    ) -> anyhow::Result<StagedBootArtifact> {
+        let fitimage = fit_artifact_path(fit_artifact)?;
         let tftp_status = self
             .tftp_status
             .as_ref()
             .ok_or_else(|| anyhow!("remote runtime not initialized"))?;
         if !runtime.use_tftp || !tftp_status.available {
-            return Ok(PreparedBootArtifact {
-                bootfile: None,
-                network_transfer_ready: false,
-            });
+            return Ok(StagedBootArtifact::no_network());
         }
 
         let fit_name = fitimage
@@ -1007,10 +992,7 @@ impl RunnerBackend for RemoteBackend {
                 )
             })?;
 
-        Ok(PreparedBootArtifact {
-            bootfile: Some(uploaded.relative_path),
-            network_transfer_ready: true,
-        })
+        Ok(StagedBootArtifact::network(uploaded.relative_path))
     }
 
     async fn finish_console(&mut self) -> anyhow::Result<()> {
@@ -1189,18 +1171,19 @@ where
             output_path: None,
         })
         .await?;
+        let fit_artifact = BootArtifact::fit_image(generated_fit.path());
 
         let prepared = self
             .backend
-            .stage_fit_image(generated_fit.path(), &runtime)
+            .stage_fit_image(&fit_artifact, &runtime)
             .await?;
 
         let bootm_arg = self.resolved_bootm_arg(fit_loadaddr, &runtime);
-        let bootcmd = if let Some(fitname) = prepared.bootfile.as_deref() {
+        let bootcmd = if let Some(fitname) = prepared.bootfile() {
             if let Some(request) = build_network_boot_request(
                 runtime.static_ip,
                 net_ok,
-                prepared.network_transfer_ready,
+                prepared.network_transfer_ready(),
                 fitname,
                 bootm_arg,
             ) {
@@ -1208,12 +1191,12 @@ where
                 request.bootcmd
             } else {
                 info!("No network boot request available, using loady to upload FIT image...");
-                Self::uboot_loady(&mut uboot, fit_loadaddr as usize, generated_fit.path()).await?;
+                Self::uboot_loady(&mut uboot, fit_loadaddr as usize, fit_artifact.path()).await?;
                 self.serial_bootm_command(bootm_arg)
             }
         } else {
             info!("No TFTP config, using loady to upload FIT image...");
-            Self::uboot_loady(&mut uboot, fit_loadaddr as usize, generated_fit.path()).await?;
+            Self::uboot_loady(&mut uboot, fit_loadaddr as usize, fit_artifact.path()).await?;
             self.serial_bootm_command(bootm_arg)
         };
 
@@ -1429,6 +1412,17 @@ fn timeout_duration(timeout: Option<u64>) -> Option<Duration> {
     }
 }
 
+fn fit_artifact_path(fit_artifact: &BootArtifact) -> anyhow::Result<&Path> {
+    if fit_artifact.kind() != BootArtifactKind::FitImage {
+        return Err(anyhow!(
+            "expected FIT image boot artifact, got {:?}",
+            fit_artifact.kind()
+        ));
+    }
+
+    Ok(fit_artifact.path())
+}
+
 fn build_network_boot_request(
     static_ip: bool,
     net_ok: bool,
@@ -1470,13 +1464,19 @@ mod tests {
     use std::{collections::HashMap, time::Duration};
 
     use super::{
-        LocalUbootConfig, Net, UbootConfig, build_network_boot_request, ensure_config_in_dir,
+        LocalBackend, LocalUbootConfig, Net, RemoteBackend, ResolvedRuntime, RunnerBackend,
+        UbootConfig, build_network_boot_request, ensure_config_in_dir, fit_artifact_path,
         timeout_duration,
     };
     use crate::{
-        board::config::BoardRunConfig,
+        board::{
+            client::{BoardServerClient, SessionCreatedResponse, TftpSessionResponse},
+            config::BoardRunConfig,
+        },
+        boot::artifacts::BootArtifact,
         build::config::{BuildConfig, BuildSystem, Cargo},
         invocation::{Invocation, InvocationOptions},
+        run::tftp,
     };
 
     fn make_invocation(dir: &std::path::Path) -> Invocation {
@@ -1487,6 +1487,23 @@ mod tests {
             false,
         ))
         .unwrap()
+    }
+
+    fn local_backend() -> LocalBackend {
+        LocalBackend {
+            config: LocalUbootConfig::default(),
+            baud_rate: None,
+            linux_system_tftp: None,
+            existing_tftp_dir: None,
+            builtin_tftp_started: false,
+        }
+    }
+
+    fn write_fit_image(root: &std::path::Path) -> std::path::PathBuf {
+        let fit_path = root.join("target").join("image.fit");
+        std::fs::create_dir_all(fit_path.parent().unwrap()).unwrap();
+        std::fs::write(&fit_path, [1_u8, 2, 3, 4]).unwrap();
+        fit_path
     }
 
     #[test]
@@ -1536,6 +1553,147 @@ mod tests {
             build_network_boot_request(true, false, true, "image.fit", Some(0x82200000)).unwrap();
 
         assert_eq!(request.bootcmd, "tftp image.fit && bootm 0x82200000");
+    }
+
+    #[test]
+    fn fit_artifact_path_rejects_non_fit_artifacts() {
+        let artifact = BootArtifact::qemu_dtb_dump("target/qemu.dtb");
+        let err = fit_artifact_path(&artifact).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("expected FIT image boot artifact, got QemuDtbDump")
+        );
+    }
+
+    #[tokio::test]
+    async fn local_stage_fit_image_without_network_disables_transfer() {
+        let temp = tempfile::tempdir().unwrap();
+        let fit_path = write_fit_image(temp.path());
+        let mut backend = local_backend();
+
+        let staged = backend
+            .stage_fit_image(
+                &BootArtifact::fit_image(&fit_path),
+                &ResolvedRuntime::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(staged.bootfile(), None);
+        assert!(!staged.network_transfer_ready());
+    }
+
+    #[tokio::test]
+    async fn local_stage_fit_image_uses_existing_tftp_dir_display_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let fit_path = write_fit_image(temp.path());
+        let tftp_dir = temp.path().join("tftp-root");
+        let mut backend = local_backend();
+        backend.existing_tftp_dir = Some(tftp_dir.clone());
+
+        let staged = backend
+            .stage_fit_image(
+                &BootArtifact::fit_image(&fit_path),
+                &ResolvedRuntime::default(),
+            )
+            .await
+            .unwrap();
+
+        let expected = tftp_dir.join("image.fit").display().to_string();
+        assert_eq!(staged.bootfile(), Some(expected.as_str()));
+        assert!(staged.network_transfer_ready());
+    }
+
+    #[tokio::test]
+    async fn local_stage_fit_image_uses_builtin_tftp_filename() {
+        let temp = tempfile::tempdir().unwrap();
+        let fit_path = write_fit_image(temp.path());
+        let mut backend = local_backend();
+        backend.builtin_tftp_started = true;
+
+        let staged = backend
+            .stage_fit_image(
+                &BootArtifact::fit_image(&fit_path),
+                &ResolvedRuntime::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(staged.bootfile(), Some("image.fit"));
+        assert!(staged.network_transfer_ready());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn local_stage_fit_image_copies_to_linux_tftp_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let fit_path = write_fit_image(temp.path());
+        let tftp_root = temp.path().join("srv-tftp");
+        let mut backend = local_backend();
+        backend.linux_system_tftp = Some(tftp::TftpdHpaConfig {
+            username: None,
+            directory: tftp_root.clone(),
+            address: None,
+            options: None,
+        });
+
+        let staged = backend
+            .stage_fit_image(
+                &BootArtifact::fit_image(&fit_path),
+                &ResolvedRuntime::default(),
+            )
+            .await
+            .unwrap();
+
+        let relative_filename = tftp::relative_tftp_filename(&fit_path).unwrap();
+        assert_eq!(staged.bootfile(), Some(relative_filename.as_str()));
+        assert!(staged.network_transfer_ready());
+        assert_eq!(
+            std::fs::read(tftp_root.join(relative_filename)).unwrap(),
+            [1_u8, 2, 3, 4]
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_stage_fit_image_without_tftp_disables_transfer() {
+        let temp = tempfile::tempdir().unwrap();
+        let fit_path = write_fit_image(temp.path());
+        let mut backend = RemoteBackend {
+            client: BoardServerClient::new("127.0.0.1", 8080).unwrap(),
+            session: SessionCreatedResponse {
+                session_id: "demo".into(),
+                board_id: "board-1".into(),
+                lease_expires_at: chrono::Utc::now(),
+                serial_available: true,
+                boot_mode: "uboot".into(),
+                ws_url: None,
+            },
+            boot_profile: None,
+            serial_status: None,
+            tftp_status: Some(TftpSessionResponse {
+                available: false,
+                provider: "none".into(),
+                server_ip: None,
+                netmask: None,
+                writable: false,
+                files: vec![],
+            }),
+            session_dtb: None,
+            console_tasks: None,
+        };
+        let runtime = ResolvedRuntime {
+            use_tftp: true,
+            ..Default::default()
+        };
+
+        let staged = backend
+            .stage_fit_image(&BootArtifact::fit_image(&fit_path), &runtime)
+            .await
+            .unwrap();
+
+        assert_eq!(staged.bootfile(), None);
+        assert!(!staged.network_transfer_ready());
     }
 
     #[test]

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -7,11 +7,9 @@ use std::{
 
 use anyhow::Context;
 use async_trait::async_trait;
-use byte_unit::Byte;
 use colored::Colorize;
-use fitimage::{ComponentConfig, FitImageBuilder, FitImageConfig};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
-use log::{info, warn};
+use log::info;
 use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -40,6 +38,7 @@ use crate::{
             BoxedAsyncRead, BoxedAsyncWrite, SerialStreamTasks, connect_serial_stream,
         },
     },
+    boot::fit::{self, FitInput},
     invocation::Invocation,
     process::ProcessContext,
     project::variables::{self, VariableScope},
@@ -53,15 +52,6 @@ use crate::{
     sterm::{AsyncTerminal, TerminalConfig},
     utils::PathResultExt,
 };
-
-/// FIT image 生成相关的错误消息常量
-mod errors {
-    pub const KERNEL_READ_ERROR: &str = "读取 kernel 文件失败";
-    pub const DTB_READ_ERROR: &str = "读取 DTB 文件失败";
-    pub const FIT_BUILD_ERROR: &str = "构建 FIT image 失败";
-    pub const FIT_SAVE_ERROR: &str = "保存 FIT image 失败";
-    pub const DIR_ERROR: &str = "无法获取 kernel 文件目录";
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct UbootConfig {
@@ -1049,109 +1039,6 @@ where
         }
     }
 
-    /// 生成包含 kernel 和 FDT 的压缩 FIT image。
-    async fn generate_fit_image(
-        &self,
-        kernel_path: &Path,
-        dtb_path: Option<&Path>,
-        kernel_load_addr: u64,
-        kernel_entry_addr: u64,
-        fdt_load_addr: Option<u64>,
-        _ramfs_load_addr: Option<u64>,
-    ) -> anyhow::Result<PathBuf> {
-        info!("Making FIT image...");
-        // 生成压缩的 FIT image
-        let output_dir = kernel_path
-            .parent()
-            .and_then(|p| p.to_str())
-            .ok_or_else(|| anyhow!("{}: {}", errors::DIR_ERROR, kernel_path.display()))?;
-
-        // 读取 kernel 数据
-        let kernel_data = fs::read(kernel_path)
-            .await
-            .with_path(errors::KERNEL_READ_ERROR, kernel_path)?;
-
-        info!(
-            "kernel: {} (size: {:.2})",
-            kernel_path.display(),
-            Byte::from(kernel_data.len())
-        );
-
-        let arch = self
-            .input
-            .arch
-            .ok_or_else(|| anyhow!("Cannot determine architecture for FIT image generation"))?;
-        let arch = match arch {
-            object::Architecture::Aarch64 => "arm64",
-            object::Architecture::Arm => "arm",
-            object::Architecture::LoongArch64 => "loongarch64",
-            object::Architecture::Riscv64 => "riscv",
-            other => anyhow::bail!("unsupported architecture for FIT image generation: {other:?}"),
-        };
-
-        let mut config = FitImageConfig::new("Various kernels, ramdisks and FDT blobs")
-            .with_kernel(
-                ComponentConfig::new("kernel", kernel_data)
-                    .with_description("This kernel")
-                    .with_type("kernel")
-                    .with_arch(arch)
-                    .with_os("linux")
-                    .with_compression(false)
-                    .with_load_address(kernel_load_addr)
-                    .with_entry_point(kernel_entry_addr),
-            );
-        let mut fdt_name = None;
-
-        // 处理 DTB 文件
-        if let Some(dtb_path) = dtb_path {
-            let data = fs::read(dtb_path)
-                .await
-                .with_path(errors::DTB_READ_ERROR, dtb_path)?;
-            info!(
-                "已读取 DTB 文件: {} (大小: {:.2})",
-                dtb_path.display(),
-                Byte::from(data.len())
-            );
-            fdt_name = Some("fdt");
-
-            // U-Boot 不接受压缩的 DTB
-            let mut fdt_config = ComponentConfig::new("fdt", data.clone())
-                .with_description("This fdt")
-                .with_type("flat_dt")
-                .with_arch(arch);
-
-            if let Some(addr) = fdt_load_addr {
-                fdt_config = fdt_config.with_load_address(addr);
-            }
-
-            config = config.with_fdt(fdt_config);
-        } else {
-            warn!("未指定 DTB 文件，将生成仅包含 kernel 的 FIT image");
-        }
-
-        config = config
-            .with_default_config("config-ostool")
-            .with_configuration(
-                "config-ostool",
-                "ostool configuration",
-                Some("kernel"),
-                fdt_name,
-                None::<String>,
-            );
-
-        let mut builder = FitImageBuilder::new();
-        let fit_data = builder
-            .build(config)
-            .with_context(|| errors::FIT_BUILD_ERROR.to_string())?;
-        let output_path = Path::new(output_dir).join("image.fit");
-        fs::write(&output_path, fit_data)
-            .await
-            .with_path(errors::FIT_SAVE_ERROR, &output_path)?;
-
-        info!("FIT image ok: {}", output_path.display());
-        Ok(output_path)
-    }
-
     async fn run(&mut self) -> anyhow::Result<()> {
         let run_result = self._run().await;
 
@@ -1240,15 +1127,11 @@ where
         }
 
         let mut fdt_load_addr = None;
-        let mut ramfs_load_addr = None;
-
         if let Ok(addr) = uboot.env_int("fdt_addr_r").await {
             fdt_load_addr = Some(addr as u64);
         }
 
-        if let Ok(addr) = uboot.env_int("ramdisk_addr_r").await {
-            ramfs_load_addr = Some(addr as u64);
-        }
+        let _ramfs_load_addr = uboot.env_int("ramdisk_addr_r").await.ok();
 
         let kernel_entry = if let Some(entry) = self
             .config
@@ -1292,18 +1175,25 @@ where
         if let Some(ref dtb_path) = prepared_dtb.fit_source {
             info!("Using DTB from: {}", dtb_path.display());
         }
-        let fitimage = self
-            .generate_fit_image(
-                &kernel,
-                prepared_dtb.fit_source.as_deref(),
-                kernel_entry,
-                kernel_entry,
-                fdt_load_addr,
-                ramfs_load_addr,
-            )
-            .await?;
+        let arch = self
+            .input
+            .arch
+            .ok_or_else(|| anyhow!("Cannot determine architecture for FIT image generation"))?;
+        let generated_fit = fit::generate_fit_image(FitInput {
+            kernel_path: kernel.clone(),
+            dtb_path: prepared_dtb.fit_source.clone(),
+            arch,
+            kernel_load_addr: kernel_entry,
+            kernel_entry_addr: kernel_entry,
+            fdt_load_addr,
+            output_path: None,
+        })
+        .await?;
 
-        let prepared = self.backend.stage_fit_image(&fitimage, &runtime).await?;
+        let prepared = self
+            .backend
+            .stage_fit_image(generated_fit.path(), &runtime)
+            .await?;
 
         let bootm_arg = self.resolved_bootm_arg(fit_loadaddr, &runtime);
         let bootcmd = if let Some(fitname) = prepared.bootfile.as_deref() {
@@ -1318,12 +1208,12 @@ where
                 request.bootcmd
             } else {
                 info!("No network boot request available, using loady to upload FIT image...");
-                Self::uboot_loady(&mut uboot, fit_loadaddr as usize, fitimage).await?;
+                Self::uboot_loady(&mut uboot, fit_loadaddr as usize, generated_fit.path()).await?;
                 self.serial_bootm_command(bootm_arg)
             }
         } else {
             info!("No TFTP config, using loady to upload FIT image...");
-            Self::uboot_loady(&mut uboot, fit_loadaddr as usize, fitimage).await?;
+            Self::uboot_loady(&mut uboot, fit_loadaddr as usize, generated_fit.path()).await?;
             self.serial_bootm_command(bootm_arg)
         };
 


### PR DESCRIPTION
## 摘要

- 抽出 crate-private `boot::fit` 模块，集中处理 U-Boot FIT image 生成。
- 抽出 crate-private `boot::artifacts` 模块，集中表达 boot artifact kind/path、QEMU DTB dump artifact 和 U-Boot staging result。
- 将 FIT arch 映射、默认 `image.fit` 输出路径、默认 Linux kernel/FDT 配置和 FIT 写文件逻辑移出 U-Boot runner。
- 将 QEMU `dtb_dump` 的默认 `target/qemu.dtb` 路径和旧文件清理移出 runner 主流程，同时保留现有 `-machine dumpdtb=...` 参数行为。
- 将 U-Boot runner-local `PreparedBootArtifact` 收敛为 `StagedBootArtifact`，并让 backend staging 通过 `BootArtifact::fit_image()` 消费生成后的 FIT image。

## 变更模块

- `ostool/src/boot/fit.rs`: 新增 FIT generator、`FitInput`、`GeneratedFitImage`、arch mapping、默认输出路径和默认 FIT config 构造逻辑。
- `ostool/src/boot/artifacts.rs`: 新增 `BootArtifact`、`QemuDtbDumpArtifact`、`StagedBootArtifact`、默认 QEMU DTB dump path 和 cleanup helper。
- `ostool/src/boot/mod.rs`, `ostool/src/lib.rs`: 接入 crate-private boot helper module，不新增 public Rust API。
- `ostool/src/run/qemu.rs`: 调用 `prepare_qemu_dtb_dump()` 获取 DTB dump artifact path，保留原有 QEMU 参数行为。
- `ostool/src/run/uboot.rs`: 删除直接 `fitimage` 构造逻辑，改为解析地址后调用 `boot::fit::generate_fit_image()`；用 `StagedBootArtifact` 替代 runner-local `PreparedBootArtifact`，并通过 `BootArtifact::fit_image()` 传递 generated FIT image。

## 兼容性

- 不新增 CLI 参数、命令或配置字段。
- 不改变 `.qemu.toml`、`.uboot.toml` 或 `.board.toml` 语义。
- 不改变默认 FIT 输出路径、kernel/FDT component 默认值或 unsupported architecture 错误语义。
- 不改变 QEMU `dtb_dump` 默认路径、旧文件清理或 `dumpdtb` 参数行为。
- 不改变 U-Boot Linux system TFTP、existing TFTP dir、built-in TFTP、remote upload、YMODEM fallback 或 `bootm` 行为。
- 不改变 runtime `.elf` / `.bin` artifact state，也不把 boot artifact 混入 runtime/debug artifact registry。
- 新增类型和 helper 都保持 crate-private，不扩大 public Rust API。

## 验证

已运行并通过：

- `cargo fmt --all -- --check`
- `cargo test -p ostool`
- `cargo clippy -p ostool --all-targets --all-features -- -D warnings`
- `git diff --check`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features`
- `cargo build --target x86_64-unknown-linux-gnu --all-features`
- `cargo test --target x86_64-unknown-linux-gnu -- --nocapture`

## 风险 / 后续

- 本 PR 只建立内部 FIT generator 和 boot artifact staging/value-type 边界，不新增用户可见 FIT config 或 `ostool prepare`。
- 本 PR 不实现完整 boot artifact pipeline、boot script、rootfs 或 firmware chain。
- 本 PR 只做 host-side Rust/CI target 验证，没有实际启动 U-Boot 串口、远程开发板 session 或硬件电源链路。
