### PR TITLE
fix(ostool): prepare raw bin for runtime runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ pre_build_cmds = ["make prepare"]
 # 构建后执行的命令
 post_build_cmds = ["make post-process"]
 
-# 是否输出为二进制文件
-to_bin = true
+# 可选兼容字段。U-Boot、board 和 UEFI QEMU 运行会自动准备所需 BIN。
+to_bin = false
 ```
 
 命令行 `--package`/`--bin` 会先覆盖 `.build.toml` 中的 Cargo 包/二进制选择，再用于
@@ -221,8 +221,8 @@ build_cmd = "make ARCH=aarch64 A=examples/helloworld"
 # 生成的 ELF 文件路径
 elf_path = "examples/helloworld/helloworld_aarch64-qemu-virt.elf"
 
-# 是否输出为二进制文件
-to_bin = true
+# 可选兼容字段。U-Boot、board 和 UEFI QEMU 运行会自动准备所需 BIN。
+to_bin = false
 ```
 
 ### QEMU 配置 (.qemu.toml)
@@ -236,8 +236,8 @@ args = ["-machine", "virt", "-cpu", "cortex-a57", "-nographic"]
 # 启用 UEFI 引导
 uefi = false
 
-# 输出为二进制文件
-to_bin = true
+# 可选兼容字段。UEFI QEMU 会自动准备所需 BIN。
+to_bin = false
 
 # 成功运行的正则表达式（用于自动检测）
 success_regex = ["Hello from my OS", "Kernel booted successfully"]

--- a/ostool/src/bin/cargo-osrun.rs
+++ b/ostool/src/bin/cargo-osrun.rs
@@ -26,7 +26,9 @@ struct RunnerArgs {
     /// Test name
     test_name: Option<String>,
 
-    /// Convert the ELF to a raw binary before running.
+    /// Legacy explicit request to convert the ELF to a raw binary before running.
+    ///
+    /// Runners that require BIN artifacts prepare them automatically.
     #[arg(long("to-bin"))]
     to_bin: bool,
 

--- a/ostool/src/board/mod.rs
+++ b/ostool/src/board/mod.rs
@@ -242,6 +242,7 @@ pub async fn run_board(
 ) -> anyhow::Result<()> {
     crate::build::prepare_runtime_artifacts(invocation, build_config, build_config_path, false)
         .await?;
+    invocation.ensure_runtime_bin()?;
     let input = crate::run::uboot::uboot_run_input(invocation)?;
     let scope = invocation.variable_scope()?;
     run_prepared_board(input, board_config, options, &scope).await

--- a/ostool/src/build/config.rs
+++ b/ostool/src/build/config.rs
@@ -13,7 +13,9 @@
 //! bin = "my-kernel"
 //! features = ["feature1", "feature2"]
 //! profile = "Release"
-//! to_bin = true
+//! # Optional legacy override. Runners that require BIN artifacts prepare them
+//! # automatically.
+//! to_bin = false
 //! ```
 
 use std::collections::HashMap;
@@ -62,7 +64,10 @@ pub struct Custom {
     pub build_cmd: String,
     /// Path to the built ELF file.
     pub elf_path: String,
-    /// Whether to convert the ELF to raw binary format.
+    /// Legacy explicit request to convert the ELF to raw binary format.
+    ///
+    /// Runners that require BIN artifacts prepare them automatically.
+    #[serde(default)]
     pub to_bin: bool,
 }
 
@@ -111,7 +116,10 @@ pub struct Cargo {
     ///
     /// The `KERNEL_ELF` environment variable is set to the built ELF path.
     pub post_build_cmds: Vec<String>,
-    /// Whether to convert the ELF to raw binary format after building.
+    /// Legacy explicit request to convert the ELF to raw binary format after building.
+    ///
+    /// Runners that require BIN artifacts prepare them automatically.
+    #[serde(default)]
     pub to_bin: bool,
 }
 
@@ -153,7 +161,7 @@ pub enum LogLevel {
 
 #[cfg(test)]
 mod tests {
-    use super::Cargo;
+    use super::{Cargo, Custom};
 
     #[test]
     fn cargo_config_defaults_someboot_injection_to_enabled_when_field_is_absent() {
@@ -172,6 +180,37 @@ to_bin = false
         .unwrap();
 
         assert!(!cargo.disable_someboot_build_config);
+    }
+
+    #[test]
+    fn cargo_config_defaults_to_bin_to_false_when_field_is_absent() {
+        let cargo: Cargo = toml::from_str(
+            r#"
+env = {}
+target = "x86_64-unknown-none"
+package = "kernel"
+features = []
+args = []
+pre_build_cmds = []
+post_build_cmds = []
+"#,
+        )
+        .unwrap();
+
+        assert!(!cargo.to_bin);
+    }
+
+    #[test]
+    fn custom_config_defaults_to_bin_to_false_when_field_is_absent() {
+        let custom: Custom = toml::from_str(
+            r#"
+build_cmd = "make"
+elf_path = "target/kernel"
+"#,
+        )
+        .unwrap();
+
+        assert!(!custom.to_bin);
     }
 
     #[test]

--- a/ostool/src/invocation.rs
+++ b/ostool/src/invocation.rs
@@ -166,6 +166,13 @@ impl Invocation {
     }
 
     pub(crate) fn ensure_runtime_bin(&mut self) -> anyhow::Result<PathBuf> {
+        self.ensure_runtime_bin_with_objcopy(ObjectTools.objcopy())
+    }
+
+    pub(crate) fn ensure_runtime_bin_with_objcopy(
+        &mut self,
+        objcopy_program: PathBuf,
+    ) -> anyhow::Result<PathBuf> {
         if let Some(bin) = self.runtime_artifacts().bin() {
             debug!("BIN file already exists: {:?}", bin);
             return Ok(bin.to_path_buf());
@@ -189,7 +196,7 @@ impl Invocation {
                     .cargo_source_artifact_dir()
                     .map(PathBuf::from),
                 strip_elf: false,
-                objcopy_program: ObjectTools.objcopy(),
+                objcopy_program,
             },
         )?;
         let bin_path = prepared

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -15,6 +15,8 @@
 //! ```toml
 //! args = ["-nographic", "-cpu", "cortex-a53"]
 //! uefi = false
+//! # `to_bin` remains supported for explicit legacy configurations, but QEMU
+//! # UEFI boot prepares the required BIN artifact automatically.
 //! to_bin = true
 //! success_regex = ["All tests passed"]
 //! fail_regex = ["PANIC", "FAILED"]
@@ -77,7 +79,11 @@ pub struct QemuConfig {
     pub args: Vec<String>,
     /// Whether to use UEFI boot via OVMF firmware.
     pub uefi: bool,
-    /// Whether build orchestration should prepare a raw BIN before loading.
+    /// Legacy explicit request to prepare a raw BIN before loading.
+    ///
+    /// Runners that require BIN artifacts, such as UEFI boot, prepare them
+    /// automatically even when this is unset.
+    #[serde(default)]
     pub to_bin: bool,
     /// Regex patterns that indicate successful execution.
     pub success_regex: Vec<String>,
@@ -131,6 +137,10 @@ impl QemuConfig {
 
     fn shell_auto_init(&self) -> Option<ShellAutoInitMatcher> {
         ShellAutoInitMatcher::new(self.shell_prefix.clone(), self.shell_init_cmd.clone())
+    }
+
+    fn requires_bin_artifact(&self) -> bool {
+        self.uefi || self.to_bin
     }
 }
 
@@ -276,10 +286,10 @@ pub(crate) async fn run_qemu_with_config(
     run_args: RunQemuOptions,
     config: QemuConfig,
 ) -> anyhow::Result<()> {
-    if config.to_bin {
+    if config.requires_bin_artifact() {
         input
             .artifacts
-            .require_bin("QEMU config `to_bin = true` requires a prepared BIN artifact")?;
+            .require_bin("QEMU runtime requires a prepared BIN artifact")?;
     }
 
     let mut runner = QemuRunner {
@@ -309,7 +319,7 @@ pub(crate) async fn run_qemu_with_debug(
 ) -> anyhow::Result<()> {
     let scope = invocation.variable_scope()?;
     let config = prepare_qemu_runtime_config(&scope, config)?;
-    if config.to_bin {
+    if config.requires_bin_artifact() {
         invocation.ensure_runtime_bin()?;
     }
     let input = QemuRunInput::new(
@@ -840,7 +850,7 @@ mod tests {
     fn write_single_crate_manifest(dir: &std::path::Path) {
         std::fs::write(
             dir.join("Cargo.toml"),
-            "[package]\nname = \"sample\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+            "[package]\nname = \"sample\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[workspace]\n",
         )
         .unwrap();
         std::fs::create_dir_all(dir.join("src")).unwrap();
@@ -1021,7 +1031,7 @@ fail_regex = []
     }
 
     #[tokio::test]
-    async fn run_qemu_with_to_bin_rejects_elf_only_artifacts() {
+    async fn run_qemu_with_config_rejects_missing_required_bin_artifact() {
         let tmp = TempDir::new().unwrap();
         write_single_crate_manifest(tmp.path());
         let source = std::env::current_exe().unwrap();
@@ -1061,7 +1071,35 @@ fail_regex = []
 
         assert!(
             err.to_string()
-                .contains("QEMU config `to_bin = true` requires a prepared BIN artifact")
+                .contains("QEMU runtime requires a prepared BIN artifact")
+        );
+    }
+
+    #[test]
+    fn qemu_config_marks_bin_required_for_uefi_and_legacy_to_bin() {
+        assert!(
+            QemuConfig {
+                uefi: true,
+                to_bin: false,
+                ..Default::default()
+            }
+            .requires_bin_artifact()
+        );
+        assert!(
+            QemuConfig {
+                uefi: false,
+                to_bin: true,
+                ..Default::default()
+            }
+            .requires_bin_artifact()
+        );
+        assert!(
+            !QemuConfig {
+                uefi: false,
+                to_bin: false,
+                ..Default::default()
+            }
+            .requires_bin_artifact()
         );
     }
 
@@ -1111,6 +1149,21 @@ timeout = 0
         .unwrap();
 
         assert_eq!(config.timeout, Some(0));
+    }
+
+    #[test]
+    fn qemu_config_defaults_to_bin_to_false_when_field_is_absent() {
+        let config: QemuConfig = toml::from_str(
+            r#"
+args = ["-nographic"]
+uefi = false
+success_regex = []
+fail_regex = []
+"#,
+        )
+        .unwrap();
+
+        assert!(!config.to_bin);
     }
 
     #[test]

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -407,6 +407,7 @@ pub(crate) async fn run_uboot_with_config(
 pub async fn run_uboot(invocation: &mut Invocation, config: &UbootConfig) -> anyhow::Result<()> {
     let scope = invocation.variable_scope()?;
     let config = prepare_uboot_runtime_config(&scope, config)?;
+    invocation.ensure_runtime_bin()?;
     let input = uboot_run_input(invocation)?;
     run_uboot_with_config(input, config).await
 }
@@ -1047,8 +1048,7 @@ where
         let kernel = self
             .input
             .artifacts
-            .runtime_image()
-            .ok_or_else(|| anyhow!("U-Boot runner requires a prepared runtime image"))?
+            .require_bin("U-Boot runner requires a prepared BIN artifact")?
             .to_path_buf();
 
         info!("Starting U-Boot runner...");
@@ -1469,6 +1469,10 @@ mod tests {
         timeout_duration,
     };
     use crate::{
+        artifact::{
+            object_tools::ObjectTools,
+            runtime::{RuntimeArtifactOptions, prepare_runtime_artifacts},
+        },
         board::{
             client::{BoardServerClient, SessionCreatedResponse, TftpSessionResponse},
             config::BoardRunConfig,
@@ -1489,6 +1493,16 @@ mod tests {
         .unwrap()
     }
 
+    fn write_single_crate_manifest(dir: &std::path::Path) {
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"sample\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[workspace]\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(dir.join("src/lib.rs"), "").unwrap();
+    }
+
     fn local_backend() -> LocalBackend {
         LocalBackend {
             config: LocalUbootConfig::default(),
@@ -1504,6 +1518,31 @@ mod tests {
         std::fs::create_dir_all(fit_path.parent().unwrap()).unwrap();
         std::fs::write(&fit_path, [1_u8, 2, 3, 4]).unwrap();
         fit_path
+    }
+
+    fn prepare_elf_only_invocation(dir: &std::path::Path) -> Invocation {
+        let source = std::env::current_exe().unwrap();
+        let copied = dir.join("sample-elf");
+        std::fs::copy(source, &copied).unwrap();
+
+        let mut invocation = make_invocation(dir);
+        let prepared = prepare_runtime_artifacts(
+            &invocation.process_context().unwrap(),
+            RuntimeArtifactOptions {
+                elf_path: copied,
+                to_bin: false,
+                bin_dir: None,
+                debug: false,
+                cargo_artifact_dir: None,
+                strip_elf: false,
+                objcopy_program: ObjectTools.objcopy(),
+            },
+        )
+        .unwrap();
+        invocation.apply_prepared_runtime_artifacts(prepared);
+        assert!(invocation.runtime_artifacts().elf().is_some());
+        assert!(invocation.runtime_artifacts().bin().is_none());
+        invocation
     }
 
     #[test]
@@ -1563,6 +1602,37 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("expected FIT image boot artifact, got QemuDtbDump")
+        );
+    }
+
+    #[tokio::test]
+    async fn run_uboot_prepares_bin_for_elf_only_invocation() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_single_crate_manifest(tmp.path());
+        let mut invocation = prepare_elf_only_invocation(tmp.path());
+
+        let err = super::run_uboot(&mut invocation, &UbootConfig::default())
+            .await
+            .unwrap_err();
+
+        assert!(invocation.runtime_artifacts().bin().is_some());
+        assert!(err.to_string().contains("local U-Boot backend requires"));
+    }
+
+    #[tokio::test]
+    async fn run_uboot_with_config_rejects_elf_only_input() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_single_crate_manifest(tmp.path());
+        let invocation = prepare_elf_only_invocation(tmp.path());
+        let input = super::uboot_run_input(&invocation).unwrap();
+
+        let err = super::run_uboot_with_config(input, UbootConfig::default())
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("U-Boot runner requires a prepared BIN artifact")
         );
     }
 

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -26,7 +26,7 @@ use tokio_util::compat::{
 use uboot_shell::UbootShell;
 
 use crate::{
-    artifact::state::OutputArtifacts,
+    artifact::{object_tools::ObjectTools, state::OutputArtifacts},
     board::{
         client::{
             BoardServerClient, BootConfig as RemoteBootConfig, BootProfileResponse,
@@ -405,9 +405,17 @@ pub(crate) async fn run_uboot_with_config(
 
 /// Runs an already prepared artifact via U-Boot.
 pub async fn run_uboot(invocation: &mut Invocation, config: &UbootConfig) -> anyhow::Result<()> {
+    run_uboot_with_objcopy(invocation, config, ObjectTools.objcopy()).await
+}
+
+async fn run_uboot_with_objcopy(
+    invocation: &mut Invocation,
+    config: &UbootConfig,
+    objcopy_program: PathBuf,
+) -> anyhow::Result<()> {
     let scope = invocation.variable_scope()?;
     let config = prepare_uboot_runtime_config(&scope, config)?;
-    invocation.ensure_runtime_bin()?;
+    invocation.ensure_runtime_bin_with_objcopy(objcopy_program)?;
     let input = uboot_run_input(invocation)?;
     run_uboot_with_config(input, config).await
 }
@@ -1461,7 +1469,7 @@ fn bootm_command(bootm_arg: Option<u64>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, time::Duration};
+    use std::{collections::HashMap, path::Path, time::Duration};
 
     use super::{
         LocalBackend, LocalUbootConfig, Net, RemoteBackend, ResolvedRuntime, RunnerBackend,
@@ -1518,6 +1526,23 @@ mod tests {
         std::fs::create_dir_all(fit_path.parent().unwrap()).unwrap();
         std::fs::write(&fit_path, [1_u8, 2, 3, 4]).unwrap();
         fit_path
+    }
+
+    fn write_fake_rust_objcopy(dir: &Path) -> std::path::PathBuf {
+        let script = dir.join("fake-rust-objcopy");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\nlast=\"\"\nprev=\"\"\nfor arg in \"$@\"; do prev=\"$last\"; last=\"$arg\"; done\ncp \"$prev\" \"$last\"\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&script, permissions).unwrap();
+        }
+        script
     }
 
     fn prepare_elf_only_invocation(dir: &std::path::Path) -> Invocation {
@@ -1609,11 +1634,16 @@ mod tests {
     async fn run_uboot_prepares_bin_for_elf_only_invocation() {
         let tmp = tempfile::tempdir().unwrap();
         write_single_crate_manifest(tmp.path());
+        let objcopy_program = write_fake_rust_objcopy(tmp.path());
         let mut invocation = prepare_elf_only_invocation(tmp.path());
 
-        let err = super::run_uboot(&mut invocation, &UbootConfig::default())
-            .await
-            .unwrap_err();
+        let err = super::run_uboot_with_objcopy(
+            &mut invocation,
+            &UbootConfig::default(),
+            objcopy_program,
+        )
+        .await
+        .unwrap_err();
 
         assert!(invocation.runtime_artifacts().bin().is_some());
         assert!(err.to_string().contains("local U-Boot backend requires"));


### PR DESCRIPTION
## 问题

ostool 0.22 的 U-Boot/board 运行路径在构造 FIT kernel 时可能直接使用 ELF 作为运行镜像。对于需要 raw BIN 的 U-Boot 启动场景，这会导致加载地址处不是可直接执行的镜像内容，板端启动后可能出现同步异常。

## 修改

- U-Boot 公共运行入口在构造运行输入前自动准备 raw BIN。
- board 远程运行路径在准备 runtime artifact 后自动补齐 raw BIN。
- U-Boot 低层 runner 不再从 BIN fallback 到 ELF，缺少 BIN 时直接报错。
- QEMU 增加内部 `requires_bin_artifact` 判断，UEFI 或兼容字段 `to_bin = true` 时统一要求 BIN，并由公共入口自动准备。
- `to_bin` 保留为兼容字段，但 Cargo/Custom/QEMU 配置中该字段现在可以省略，默认 false。
- 更新 README 和 CLI help，说明需要 BIN 的 runner 会自行准备。

## 验证

- `cargo fmt --check`
- `TMPDIR=/var/tmp cargo test -p ostool`
- `TMPDIR=/var/tmp cargo clippy -p ostool --all-targets`

本地 `/tmp/Cargo.toml` 存在其他 workspace 副本，会干扰使用默认临时目录的 cargo metadata 测试，因此全量测试使用 `TMPDIR=/var/tmp` 跑在干净临时目录下。