### PR TITLE
refactor(tool): 抽出 QEMU command 与 runner 执行边界

### DIFF
--- a/ostool/src/run/execution.rs
+++ b/ostool/src/run/execution.rs
@@ -1,0 +1,195 @@
+//! Crate-private runner execution summaries.
+//!
+//! Runners still expose `anyhow::Result<()>`; this module keeps the internal
+//! success/failure mapping reusable for future system-test aggregation.
+
+use std::{process::ExitStatus, time::Duration};
+
+use crate::run::output_matcher::StreamMatch;
+
+#[derive(Debug)]
+pub(crate) enum RunnerExitStatus {
+    Process(ExitStatus),
+    NotAvailable,
+}
+
+impl RunnerExitStatus {
+    pub(crate) fn process(status: ExitStatus) -> Self {
+        Self::Process(status)
+    }
+
+    pub(crate) fn not_available() -> Self {
+        Self::NotAvailable
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RunnerExecutionSummary {
+    runner: &'static str,
+    exit_status: RunnerExitStatus,
+    stream_match: Option<StreamMatch>,
+    terminal_error: Option<anyhow::Error>,
+    stderr_log: Option<String>,
+    elapsed: Duration,
+}
+
+impl RunnerExecutionSummary {
+    pub(crate) fn new(
+        runner: &'static str,
+        exit_status: RunnerExitStatus,
+        elapsed: Duration,
+    ) -> Self {
+        Self {
+            runner,
+            exit_status,
+            stream_match: None,
+            terminal_error: None,
+            stderr_log: None,
+            elapsed,
+        }
+    }
+
+    pub(crate) fn with_stream_match(mut self, stream_match: Option<StreamMatch>) -> Self {
+        self.stream_match = stream_match;
+        self
+    }
+
+    pub(crate) fn with_terminal_error(mut self, terminal_error: Option<anyhow::Error>) -> Self {
+        self.terminal_error = terminal_error;
+        self
+    }
+
+    pub(crate) fn with_stderr_log(mut self, stderr: &[u8]) -> Self {
+        self.stderr_log = Some(String::from_utf8_lossy(stderr).into_owned());
+        self
+    }
+
+    #[cfg(test)]
+    fn runner(&self) -> &'static str {
+        self.runner
+    }
+
+    #[cfg(test)]
+    fn elapsed(&self) -> Duration {
+        self.elapsed
+    }
+
+    pub(crate) fn into_result(self) -> anyhow::Result<()> {
+        let Self {
+            runner,
+            exit_status,
+            stream_match,
+            terminal_error,
+            stderr_log,
+            elapsed,
+        } = self;
+        let _ = (runner, elapsed);
+
+        if let Some(err) = terminal_error {
+            return Err(err);
+        }
+
+        if let Some(matched) = stream_match {
+            matched.kind.into_result(&matched)?;
+            return Ok(());
+        }
+
+        if let RunnerExitStatus::Process(status) = exit_status
+            && !status.success()
+        {
+            return Err(anyhow::anyhow!("{}", stderr_log.unwrap_or_default()));
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) fn timeout_duration(timeout: Option<u64>) -> Option<Duration> {
+    match timeout {
+        Some(0) | None => None,
+        Some(secs) => Some(Duration::from_secs(secs)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RunnerExecutionSummary, RunnerExitStatus, timeout_duration};
+    use crate::run::output_matcher::{StreamMatch, StreamMatchKind};
+    use std::time::{Duration, Instant};
+
+    fn stream_match(kind: StreamMatchKind) -> StreamMatch {
+        StreamMatch {
+            kind,
+            matched_regex: "READY|PANIC".into(),
+            matched_text: "kernel READY".into(),
+            deadline: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn timeout_zero_and_none_disable_timeout() {
+        assert_eq!(timeout_duration(None), None);
+        assert_eq!(timeout_duration(Some(0)), None);
+        assert_eq!(timeout_duration(Some(5)), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn summary_preserves_success_match_as_ok() {
+        let summary = RunnerExecutionSummary::new(
+            "test runner",
+            RunnerExitStatus::not_available(),
+            Duration::from_millis(7),
+        )
+        .with_stream_match(Some(stream_match(StreamMatchKind::Success)));
+
+        assert_eq!(summary.runner(), "test runner");
+        assert_eq!(summary.elapsed(), Duration::from_millis(7));
+        summary.into_result().unwrap();
+    }
+
+    #[test]
+    fn summary_preserves_fail_match_error() {
+        let err = RunnerExecutionSummary::new(
+            "test runner",
+            RunnerExitStatus::not_available(),
+            Duration::ZERO,
+        )
+        .with_stream_match(Some(stream_match(StreamMatchKind::Fail)))
+        .into_result()
+        .unwrap_err();
+
+        assert!(err.to_string().contains("Fail pattern matched"));
+    }
+
+    #[test]
+    fn summary_returns_terminal_error_before_match_result() {
+        let err = RunnerExecutionSummary::new(
+            "test runner",
+            RunnerExitStatus::not_available(),
+            Duration::ZERO,
+        )
+        .with_terminal_error(Some(anyhow::anyhow!("terminal timed out")))
+        .with_stream_match(Some(stream_match(StreamMatchKind::Success)))
+        .into_result()
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "terminal timed out");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn summary_maps_nonzero_process_status_to_stderr_log() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let err = RunnerExecutionSummary::new(
+            "test runner",
+            RunnerExitStatus::process(ExitStatusExt::from_raw(1 << 8)),
+            Duration::ZERO,
+        )
+        .with_stderr_log(b"boot failed")
+        .into_result()
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "boot failed");
+    }
+}

--- a/ostool/src/run/mod.rs
+++ b/ostool/src/run/mod.rs
@@ -10,6 +10,12 @@
 /// QEMU emulator runner with UEFI/OVMF support.
 pub mod qemu;
 
+/// Crate-private runner execution summaries.
+pub(crate) mod execution;
+
+/// Crate-private QEMU command planning.
+pub(crate) mod qemu_plan;
+
 /// TFTP server for network booting.
 pub(crate) mod tftp;
 

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -29,7 +29,7 @@ use std::{
     path::PathBuf,
     process::Stdio,
     sync::{Arc, Mutex},
-    time::Duration,
+    time::Instant,
 };
 
 use anyhow::{Context, anyhow};
@@ -54,8 +54,10 @@ use crate::{
     project::variables::{self, VariableScope},
     project::{ProjectLayout, metadata},
     run::{
+        execution::{RunnerExecutionSummary, RunnerExitStatus, timeout_duration},
         output_matcher::{ByteStreamMatcher, compile_regexes, print_match_event},
         ovmf_prebuilt::{Arch, FileType, Prebuilt, Source},
+        qemu_plan::{QemuBootSource, QemuCommandPlanInput, build_qemu_command_plan},
         shell_init::{SHELL_INIT_DELAY, ShellAutoInitMatcher, normalize_shell_init_config},
     },
     sterm::{AsyncTerminal, TerminalConfig},
@@ -432,8 +434,6 @@ impl QemuRunner {
         }
         .to_string();
 
-        let mut need_machine = true;
-
         #[allow(unused_mut)]
         let mut qemu_executable = format!("qemu-system-{}", arch);
 
@@ -450,61 +450,47 @@ impl QemuRunner {
             }
         }
 
-        let mut cmd = crate::process::command(&qemu_executable, &self.input.process_context);
+        let dtb_dump_path = if self.dtbdump {
+            Some(
+                prepare_qemu_dtb_dump(default_qemu_dtb_dump_path())
+                    .await?
+                    .path()
+                    .to_path_buf(),
+            )
+        } else {
+            None
+        };
 
-        for arg in &self.config.args {
-            if arg == "-machine" || arg == "-M" {
-                need_machine = false;
-            }
-            cmd.arg(arg);
-        }
-
-        if self.dtbdump {
-            let dtb_dump = prepare_qemu_dtb_dump(default_qemu_dtb_dump_path()).await?;
-            cmd.arg("-machine")
-                .arg(format!("dumpdtb={}", dtb_dump.path().display()));
-            // machine = format!("{},dumpdtb=target/qemu.dtb", machine);
-        }
-
-        if need_machine {
-            cmd.arg("-machine").arg(machine);
-        }
-
-        if self.input.debug {
-            cmd.arg("-s").arg("-S");
-        }
-
-        let mut use_kernel_loader = true;
-        if let Some(uefi) = self.prepare_uefi().await? {
+        let boot_source = if let Some(uefi) = self.prepare_uefi().await? {
             match uefi {
                 UefiBootConfig::Pflash {
                     code,
                     vars,
                     esp_dir,
-                } => {
-                    cmd.arg("-drive").arg(format!(
-                        "if=pflash,format=raw,unit=0,readonly=on,file={}",
-                        code.display()
-                    ));
-                    cmd.arg("-drive").arg(format!(
-                        "if=pflash,format=raw,unit=1,file={}",
-                        vars.display()
-                    ));
-                    cmd.arg("-drive")
-                        .arg(format!("format=raw,file=fat:rw:{}", esp_dir.display()));
-                    use_kernel_loader = false;
-                }
+                } => Some(QemuBootSource::uefi_pflash(code, vars, esp_dir)),
             }
-        }
+        } else {
+            self.input
+                .artifacts
+                .runtime_image()
+                .map(|path| QemuBootSource::direct_kernel_loader(path.to_path_buf()))
+        };
 
-        if use_kernel_loader && let Some(kernel_path) = self.input.artifacts.runtime_image() {
-            cmd.arg("-kernel").arg(kernel_path);
-        }
+        let plan = build_qemu_command_plan(QemuCommandPlanInput {
+            executable: qemu_executable,
+            config_args: self.config.args.iter().map(OsString::from).collect(),
+            default_machine: machine,
+            dtb_dump_path,
+            debug: self.input.debug,
+            boot_source,
+        });
+        let mut cmd = plan.render(&self.input.process_context);
         cmd.stdin(Stdio::piped());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
         cmd.print_cmd();
         let mut child = TokioCommand::from(cmd.into_std()).spawn()?;
+        let started_at = Instant::now();
         let stdin = child.stdin.take().context("failed to capture QEMU stdin")?;
         let stdout = child
             .stdout
@@ -544,7 +530,7 @@ impl QemuRunner {
             self.fail_regex.clone(),
         )));
         let shell_auto_init = Arc::new(Mutex::new(self.config.shell_auto_init()));
-        let match_result = Arc::new(Mutex::new(None::<anyhow::Result<()>>));
+        let match_result = Arc::new(Mutex::new(None));
         let terminal = AsyncTerminal::new(TerminalConfig {
             intercept_exit_sequence: false,
             timeout: timeout_duration(self.config.timeout),
@@ -561,7 +547,7 @@ impl QemuRunner {
                     if let Some(matched) = matcher.observe_byte(byte) {
                         print_match_event(&matched);
                         let mut result = match_result.lock().unwrap();
-                        *result = Some(matched.kind.into_result(&matched));
+                        *result = Some(matched);
                         handle.stop_after(crate::run::output_matcher::MATCH_DRAIN_DURATION);
                     }
 
@@ -596,20 +582,16 @@ impl QemuRunner {
         let _ = stderr_task.await;
         let _ = write_task.await;
 
-        terminal_result?;
-
-        if let Some(result) = match_result.lock().unwrap().take() {
-            result?;
-        } else if !status.success() {
-            unsafe {
-                return Err(anyhow::anyhow!(
-                    "{}",
-                    OsString::from_encoded_bytes_unchecked(stderr_capture.lock().unwrap().clone())
-                        .to_string_lossy()
-                ));
-            }
-        }
-        Ok(())
+        let stderr = stderr_capture.lock().unwrap().clone();
+        RunnerExecutionSummary::new(
+            "QEMU",
+            RunnerExitStatus::process(status),
+            started_at.elapsed(),
+        )
+        .with_terminal_error(terminal_result.err())
+        .with_stream_match(match_result.lock().unwrap().take())
+        .with_stderr_log(&stderr)
+        .into_result()
     }
 
     async fn prepare_uefi(&self) -> anyhow::Result<Option<UefiBootConfig>> {
@@ -781,13 +763,6 @@ pub(crate) fn resolve_qemu_config_path_in_dir(
     };
 
     Ok(search_dir.join(default_filename))
-}
-
-fn timeout_duration(timeout: Option<u64>) -> Option<Duration> {
-    match timeout {
-        Some(0) | None => None,
-        Some(secs) => Some(Duration::from_secs(secs)),
-    }
 }
 
 async fn read_child_stream<R>(

--- a/ostool/src/run/qemu_plan.rs
+++ b/ostool/src/run/qemu_plan.rs
@@ -1,0 +1,274 @@
+//! Crate-private QEMU command planning.
+//!
+//! This module keeps command argument ordering testable without owning runtime
+//! side effects such as OVMF preparation, DTB cleanup, stdio, or process spawn.
+
+use std::{
+    ffi::{OsStr, OsString},
+    path::PathBuf,
+};
+
+use crate::{process::ProcessContext, utils::Command};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum QemuBootSource {
+    DirectKernelLoader {
+        path: PathBuf,
+    },
+    UefiPflash {
+        code: PathBuf,
+        vars: PathBuf,
+        esp_dir: PathBuf,
+    },
+}
+
+impl QemuBootSource {
+    pub(crate) fn direct_kernel_loader(path: impl Into<PathBuf>) -> Self {
+        Self::DirectKernelLoader { path: path.into() }
+    }
+
+    pub(crate) fn uefi_pflash(
+        code: impl Into<PathBuf>,
+        vars: impl Into<PathBuf>,
+        esp_dir: impl Into<PathBuf>,
+    ) -> Self {
+        Self::UefiPflash {
+            code: code.into(),
+            vars: vars.into(),
+            esp_dir: esp_dir.into(),
+        }
+    }
+
+    fn append_args(&self, args: &mut Vec<OsString>) {
+        match self {
+            Self::DirectKernelLoader { path } => {
+                args.push("-kernel".into());
+                args.push(path.as_os_str().to_os_string());
+            }
+            Self::UefiPflash {
+                code,
+                vars,
+                esp_dir,
+            } => {
+                args.push("-drive".into());
+                args.push(
+                    format!(
+                        "if=pflash,format=raw,unit=0,readonly=on,file={}",
+                        code.display()
+                    )
+                    .into(),
+                );
+                args.push("-drive".into());
+                args.push(format!("if=pflash,format=raw,unit=1,file={}", vars.display()).into());
+                args.push("-drive".into());
+                args.push(format!("format=raw,file=fat:rw:{}", esp_dir.display()).into());
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct QemuCommandPlanInput {
+    pub(crate) executable: String,
+    pub(crate) config_args: Vec<OsString>,
+    pub(crate) default_machine: String,
+    pub(crate) dtb_dump_path: Option<PathBuf>,
+    pub(crate) debug: bool,
+    pub(crate) boot_source: Option<QemuBootSource>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct QemuCommandPlan {
+    executable: String,
+    args: Vec<OsString>,
+}
+
+impl QemuCommandPlan {
+    pub(crate) fn render(&self, context: &ProcessContext) -> Command {
+        let mut cmd = crate::process::command(&self.executable, context);
+        for arg in &self.args {
+            cmd.arg(arg);
+        }
+        cmd
+    }
+
+    #[cfg(test)]
+    fn args(&self) -> &[OsString] {
+        &self.args
+    }
+}
+
+pub(crate) fn build_qemu_command_plan(input: QemuCommandPlanInput) -> QemuCommandPlan {
+    let mut args = Vec::new();
+    let mut need_machine = true;
+
+    for arg in input.config_args {
+        if arg == OsStr::new("-machine") || arg == OsStr::new("-M") {
+            need_machine = false;
+        }
+        args.push(arg);
+    }
+
+    if let Some(dtb_dump_path) = input.dtb_dump_path {
+        args.push("-machine".into());
+        args.push(format!("dumpdtb={}", dtb_dump_path.display()).into());
+    }
+
+    if need_machine {
+        args.push("-machine".into());
+        args.push(input.default_machine.into());
+    }
+
+    if input.debug {
+        args.push("-s".into());
+        args.push("-S".into());
+    }
+
+    if let Some(boot_source) = input.boot_source {
+        boot_source.append_args(&mut args);
+    }
+
+    QemuCommandPlan {
+        executable: input.executable,
+        args,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{QemuBootSource, QemuCommandPlanInput, build_qemu_command_plan};
+    use std::{ffi::OsString, path::PathBuf};
+
+    fn plan_args(input: QemuCommandPlanInput) -> Vec<String> {
+        build_qemu_command_plan(input)
+            .args()
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn base_input() -> QemuCommandPlanInput {
+        QemuCommandPlanInput {
+            executable: "qemu-system-aarch64".into(),
+            config_args: vec![OsString::from("-nographic")],
+            default_machine: "virt".into(),
+            dtb_dump_path: None,
+            debug: false,
+            boot_source: None,
+        }
+    }
+
+    #[test]
+    fn plan_renders_direct_kernel_loader_after_default_machine() {
+        let args = plan_args(QemuCommandPlanInput {
+            boot_source: Some(QemuBootSource::direct_kernel_loader("target/kernel.elf")),
+            ..base_input()
+        });
+
+        assert_eq!(
+            args,
+            vec![
+                "-nographic",
+                "-machine",
+                "virt",
+                "-kernel",
+                "target/kernel.elf",
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_keeps_user_machine_override_and_dtb_dump_order() {
+        let args = plan_args(QemuCommandPlanInput {
+            config_args: vec![
+                OsString::from("-nographic"),
+                OsString::from("-machine"),
+                OsString::from("virt,gic-version=3"),
+            ],
+            dtb_dump_path: Some(PathBuf::from("target/qemu.dtb")),
+            ..base_input()
+        });
+
+        assert_eq!(
+            args,
+            vec![
+                "-nographic",
+                "-machine",
+                "virt,gic-version=3",
+                "-machine",
+                "dumpdtb=target/qemu.dtb",
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_keeps_short_machine_override() {
+        let args = plan_args(QemuCommandPlanInput {
+            config_args: vec![
+                OsString::from("-nographic"),
+                OsString::from("-M"),
+                OsString::from("virt"),
+            ],
+            ..base_input()
+        });
+
+        assert_eq!(args, vec!["-nographic", "-M", "virt"]);
+    }
+
+    #[test]
+    fn plan_renders_debug_before_boot_source() {
+        let args = plan_args(QemuCommandPlanInput {
+            debug: true,
+            boot_source: Some(QemuBootSource::direct_kernel_loader("target/kernel.bin")),
+            ..base_input()
+        });
+
+        assert_eq!(
+            args,
+            vec![
+                "-nographic",
+                "-machine",
+                "virt",
+                "-s",
+                "-S",
+                "-kernel",
+                "target/kernel.bin",
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_renders_uefi_pflash_without_kernel_loader() {
+        let args = plan_args(QemuCommandPlanInput {
+            boot_source: Some(QemuBootSource::uefi_pflash(
+                "OVMF_CODE.fd",
+                "kernel.vars.fd",
+                "kernel.esp",
+            )),
+            ..base_input()
+        });
+
+        assert_eq!(
+            args,
+            vec![
+                "-nographic",
+                "-machine",
+                "virt",
+                "-drive",
+                "if=pflash,format=raw,unit=0,readonly=on,file=OVMF_CODE.fd",
+                "-drive",
+                "if=pflash,format=raw,unit=1,file=kernel.vars.fd",
+                "-drive",
+                "format=raw,file=fat:rw:kernel.esp",
+            ]
+        );
+        assert!(!args.iter().any(|arg| arg == "-kernel"));
+    }
+
+    #[test]
+    fn plan_allows_no_boot_source() {
+        let args = plan_args(base_input());
+
+        assert_eq!(args, vec!["-nographic", "-machine", "virt"]);
+    }
+}

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -2,7 +2,7 @@ use std::{
     io,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, anyhow};
@@ -46,6 +46,7 @@ use crate::{
     process::ProcessContext,
     project::variables::{self, VariableScope},
     run::{
+        execution::{RunnerExecutionSummary, RunnerExitStatus, timeout_duration},
         output_matcher::{
             ByteStreamMatcher, MATCH_DRAIN_DURATION, compile_regexes, print_match_event,
         },
@@ -1218,7 +1219,7 @@ where
             self.fail_regex.clone(),
         )));
 
-        let res = Arc::new(Mutex::<Option<anyhow::Result<()>>>::new(None));
+        let res = Arc::new(Mutex::new(None));
         let res_clone = res.clone();
         let matcher_clone = matcher.clone();
         let shell_init = Arc::new(Mutex::new(self.config.shell_auto_init()));
@@ -1265,13 +1266,14 @@ where
             timeout: timeout_duration(self.config.timeout),
             timeout_label: "kernel boot".to_string(),
         });
-        terminal
+        let started_at = Instant::now();
+        let terminal_result = terminal
             .run(inbound_rx, outbound_tx, move |h, byte| {
                 let mut matcher = matcher_clone.lock().unwrap();
                 if let Some(matched) = matcher.observe_byte(byte) {
                     print_match_event(&matched);
                     let mut res_lock = res_clone.lock().unwrap();
-                    *res_lock = Some(matched.kind.into_result(&matched));
+                    *res_lock = Some(matched);
                     h.stop_after(MATCH_DRAIN_DURATION);
                 }
 
@@ -1286,7 +1288,7 @@ where
                     h.stop();
                 }
             })
-            .await?;
+            .await;
         let mut write_task = write_task;
         let write_join = tokio::time::timeout(Duration::from_secs(1), &mut write_task).await;
         match write_join {
@@ -1319,9 +1321,14 @@ where
 
         {
             let mut res_lock = res.lock().unwrap();
-            if let Some(result) = res_lock.take() {
-                result?;
-            }
+            RunnerExecutionSummary::new(
+                "kernel boot",
+                RunnerExitStatus::not_available(),
+                started_at.elapsed(),
+            )
+            .with_terminal_error(terminal_result.err())
+            .with_stream_match(res_lock.take())
+            .into_result()?;
         }
         Ok(())
     }
@@ -1411,13 +1418,6 @@ fn detect_tftp_ip(net: Option<&Net>) -> Option<String> {
 
     info!("TFTP : {}", ip_string);
     Some(ip_string)
-}
-
-fn timeout_duration(timeout: Option<u64>) -> Option<Duration> {
-    match timeout {
-        Some(0) | None => None,
-        Some(secs) => Some(Duration::from_secs(secs)),
-    }
 }
 
 fn fit_artifact_path(fit_artifact: &BootArtifact) -> anyhow::Result<&Path> {


### PR DESCRIPTION
## 摘要

- 新增 crate-private `run::qemu_plan`，把 QEMU executable、用户 args、默认 machine、`dtb_dump`、debug 和 boot source 参数组装集中到可测试的 command plan。
- 用内部 `QemuBootSource` 表达现有 direct `-kernel` 兼容路径和 UEFI pflash/ESP 启动路径，QEMU runner 只消费已准备好的路径事实。
- 新增 crate-private `run::execution`，集中映射 terminal timeout、success/fail regex 命中、进程退出状态和 stderr 输出到现有 runner 返回结果。
- QEMU 与 U-Boot runner 对外仍返回 `anyhow::Result<()>`，保持 CLI、配置字段和 public Rust API 不变。

## 整体思路

本 PR 继续收窄 runner 主流程职责：QEMU runner 仍负责 OVMF 准备、DTB cleanup、stdio、spawn、terminal 和 matcher 等副作用，但不再直接拼接完整 QEMU command。command plan builder 只接收已解析事实，便于用单元测试锁住参数顺序和 boot source 行为。

执行结果部分只建立内部 summary 边界，不改变现有错误语义。runner 在 terminal/matcher/process 完成后先构造 `RunnerExecutionSummary`，再统一还原为旧的 `anyhow::Result<()>`：terminal error 优先，其次 success/fail regex，最后处理非零进程退出状态。

## 变更模块

- `ostool/src/run/qemu_plan.rs`: 新增 `QemuCommandPlanInput`、`QemuCommandPlan`、`QemuBootSource` 和 plan builder；覆盖用户 machine override、`dtb_dump` 顺序、debug 参数、direct kernel loader 和 UEFI pflash 渲染。
- `ostool/src/run/execution.rs`: 新增 runner execution summary、runner exit status 和 shared timeout helper；覆盖 timeout 映射、success/fail matcher、terminal error 优先级和非零进程退出映射。
- `ostool/src/run/qemu.rs`: 保留 QEMU runner 的副作用边界，改为准备事实后调用 command plan，并通过 execution summary 汇总 terminal/matcher/process 结果。
- `ostool/src/run/uboot.rs`: 复用 shared timeout helper，并将 kernel boot terminal/matcher 结果汇总交给 execution summary。
- `ostool/src/run/mod.rs`: 接入 crate-private `execution` 和 `qemu_plan` 模块。

## 兼容性

- 不新增 CLI 参数、命令或配置字段。
- 不改变 `.qemu.toml`、`.uboot.toml` 或 `.board.toml` 语义。
- 不改变 QEMU 默认 direct `-kernel` 行为、UEFI pflash/ESP 参数行为、`dtb_dump` 默认路径或参数顺序。
- 不改变 U-Boot FIT staging、TFTP/YMODEM fallback、serial terminal 或 `bootm` 行为。
- 不新增 public Rust API；新增类型和 helper 都保持 crate-private。

## 验证

已运行并通过：

- `cargo fmt --all -- --check`
- `cargo test -p ostool`
- `cargo clippy -p ostool --all-targets --all-features -- -D warnings`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features`
- `cargo build --target x86_64-unknown-linux-gnu --all-features`
- `cargo test --target x86_64-unknown-linux-gnu -- --nocapture`
- `git diff --check`

## 风险 / 后续

- 本 PR 只建立内部 command plan、boot source value type 和 execution summary 边界，不新增 system test runner、repeat、Cargo `[[bin]]` 扫描或新的用户配置。
- 本 PR 没有实际验证 guest OS boot、真实 U-Boot 串口、远程开发板 session 或硬件电源链路。
