### PR TITLE
[codex] refactor CI release workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -49,3 +49,5 @@ jobs:
     - name: Unit test
       if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' }}
       run: cargo test --target ${{ matrix.targets }} -- --nocapture
+    - name: Publish dry run
+      run: cargo publish --workspace --dry-run --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,35 +5,27 @@ on:
     workflows: ["Quality Check"]
     branches: [main]
     types: [completed]
-  release:
-    types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: Release tag to package, e.g. ostool-v0.11.0 or ostool-server-v0.1.0
-        required: true
-        type: string
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  release-plz:
-    if: &release_condition ${{ github.repository_owner == 'drivercraft' && github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+  release-plz-release:
+    name: Release-plz release
+    if: &release_condition ${{ github.repository_owner == 'drivercraft' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - &checkout
         name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - &install-rust
         name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - &setup-libudenv
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
@@ -54,8 +46,8 @@ jobs:
           cache: pnpm
           cache-dependency-path: ostool-server/webui/pnpm-lock.yaml
 
-      - name: Release with release-plz
-        uses: release-plz/action@v0.5.128
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
         with:
           command: release
         env: &release_env
@@ -66,8 +58,11 @@ jobs:
     name: Release-plz PR
     if: *release_condition
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     concurrency:
-      group: release-plz-pr-${{ github.ref }}
+      group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
       - *checkout
@@ -76,75 +71,7 @@ jobs:
       - *setup-pnpm
       - *setup-node
       - name: Run release-plz
-        uses: release-plz/action@v0.5.128
+        uses: release-plz/action@v0.5
         with:
           command: release-pr
         env: *release_env
-
-  release-assets:
-    name: Build Release Assets
-    if: ${{ github.repository_owner == 'drivercraft' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    env:
-      RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
-      TARGET: x86_64-unknown-linux-gnu
-    steps:
-      - *checkout
-      - *install-rust
-      - *setup-libudenv
-      - *setup-pnpm
-      - *setup-node
-      - name: Resolve release package
-        id: release_info
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${RELEASE_TAG}"
-          case "$tag" in
-            ostool-v*)
-              package="ostool"
-              version="${tag#ostool-v}"
-              binaries="ostool cargo-osrun"
-              ;;
-            ostool-server-v*)
-              package="ostool-server"
-              version="${tag#ostool-server-v}"
-              binaries="ostool-server"
-              ;;
-            *)
-              echo "Unsupported release tag: $tag" >&2
-              exit 1
-              ;;
-          esac
-
-          echo "package=$package" >> "$GITHUB_OUTPUT"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "binaries=$binaries" >> "$GITHUB_OUTPUT"
-      - name: Build release binaries
-        run: cargo build --locked --release -p ${{ steps.release_info.outputs.package }}
-      - name: Package release archive
-        id: package_archive
-        shell: bash
-        run: |
-          set -euo pipefail
-          package="${{ steps.release_info.outputs.package }}"
-          version="${{ steps.release_info.outputs.version }}"
-          target="${TARGET}"
-          archive_root="${package}-${version}-${target}"
-          archive_name="${archive_root}.tgz"
-
-          rm -rf "$archive_root" "$archive_name"
-          mkdir -p "$archive_root"
-
-          for bin in ${{ steps.release_info.outputs.binaries }}; do
-            cp "target/release/${bin}" "${archive_root}/${bin}"
-          done
-
-          tar -czf "$archive_name" "$archive_root"
-          echo "archive=${archive_name}" >> "$GITHUB_OUTPUT"
-      - name: Upload release archive
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${RELEASE_TAG}" "${{ steps.package_archive.outputs.archive }}" --clobber


### PR DESCRIPTION
## Summary
- refactor release workflow to keep only release-plz release and release-pr jobs
- remove GitHub Release asset packaging/upload triggers and job
- add workspace `cargo publish --workspace --dry-run --locked` to Quality Check

## Notes
- release publishing remains gated on successful `Quality Check` workflow runs on `main`
- release-plz jobs now use the official template-style split permissions and `release-plz/action@v0.5`
- no Pages deploy permissions or deploy actions remain in `.github/workflows`

## Validation
- `git diff --check`
- YAML parse via Python `yaml.safe_load`
- `rg` search for Pages/release-assets residue
- `cargo fmt --all -- --check`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features` with temporary pnpm 10.33.0 wrapper
- `cargo build --target x86_64-unknown-linux-gnu --all-features` with temporary pnpm 10.33.0 wrapper
- `cargo publish --workspace --dry-run --locked` with temporary pnpm 10.33.0 wrapper

## Local test caveat
- `cargo test --target x86_64-unknown-linux-gnu -- --nocapture` was blocked locally because `mkimage` / `u-boot-tools` is missing; CI installs `u-boot-tools`.
