### PR TITLE
fix(ostool): tolerate closed serial bridge consumer

### DIFF
--- a/ostool/src/board/serial_stream.rs
+++ b/ostool/src/board/serial_stream.rs
@@ -3,6 +3,8 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
+use std::io::ErrorKind;
+
 use anyhow::Context as _;
 use futures::{SinkExt, StreamExt};
 use tokio::{
@@ -44,12 +46,12 @@ pub async fn connect_serial_stream(
             while let Some(message) = ws_stream.next().await {
                 match message.context("serial websocket read failed")? {
                     Message::Binary(bytes) => {
-                        tokio::io::AsyncWriteExt::write_all(&mut bridge_tx, &bytes)
+                        if write_bridge_bytes(&mut bridge_tx, &bytes)
                             .await
-                            .context("failed to write serial websocket bytes")?;
-                        tokio::io::AsyncWriteExt::flush(&mut bridge_tx)
-                            .await
-                            .context("failed to flush serial websocket bytes")?;
+                            .context("failed to write serial websocket bytes")?
+                        {
+                            break;
+                        }
                     }
                     Message::Text(text) => {
                         if let Ok(control) = serde_json::from_str::<ServerControlMessage>(&text) {
@@ -64,12 +66,12 @@ pub async fn connect_serial_stream(
                             }
                         }
 
-                        tokio::io::AsyncWriteExt::write_all(&mut bridge_tx, text.as_bytes())
+                        if write_bridge_bytes(&mut bridge_tx, text.as_bytes())
                             .await
-                            .context("failed to write text serial websocket payload")?;
-                        tokio::io::AsyncWriteExt::flush(&mut bridge_tx)
-                            .await
-                            .context("failed to flush text serial websocket payload")?;
+                            .context("failed to write text serial websocket payload")?
+                        {
+                            break;
+                        }
                     }
                     Message::Close(_) => {
                         if locally_closed.load(Ordering::SeqCst) {
@@ -123,6 +125,22 @@ pub async fn connect_serial_stream(
             write_task,
         },
     ))
+}
+
+async fn write_bridge_bytes<W>(writer: &mut W, bytes: &[u8]) -> anyhow::Result<bool>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    match tokio::io::AsyncWriteExt::write_all(writer, bytes).await {
+        Ok(()) => {}
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => return Ok(true),
+        Err(err) => return Err(err.into()),
+    }
+    match tokio::io::AsyncWriteExt::flush(writer).await {
+        Ok(()) => Ok(false),
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(true),
+        Err(err) => Err(err.into()),
+    }
 }
 
 impl SerialStreamTasks {
@@ -204,7 +222,7 @@ mod tests {
 
     use tokio::{sync::Notify, task::JoinHandle};
 
-    use super::SerialStreamTasks;
+    use super::{SerialStreamTasks, write_bridge_bytes};
 
     #[tokio::test]
     async fn shutdown_waits_for_writer_before_reader() {
@@ -239,5 +257,39 @@ mod tests {
         .shutdown()
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_allows_reader_to_finish_after_local_consumer_closed() {
+        let (mut writer, reader) = tokio::io::duplex(1);
+        drop(reader);
+
+        let read_task: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
+            if write_bridge_bytes(&mut writer, b"late console output").await? {
+                return Ok(());
+            }
+            anyhow::bail!("bridge writer unexpectedly stayed open")
+        });
+        let write_task: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move { Ok(()) });
+
+        SerialStreamTasks {
+            read_task,
+            write_task,
+        }
+        .shutdown()
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn bridge_writer_treats_closed_local_consumer_as_done() {
+        let (mut writer, reader) = tokio::io::duplex(1);
+        drop(reader);
+
+        assert!(
+            write_bridge_bytes(&mut writer, b"late console output")
+                .await
+                .unwrap()
+        );
     }
 }


### PR DESCRIPTION
## 问题

`tgoskits` 的 Starry self-hosted board CI 在 `ostool 0.23` 更新后，可能在 success matcher 已经命中之后仍然因为 serial bridge 清理阶段的本地 `BrokenPipe` 报错而失败。典型日志是：成功输出已经出现，但随后 runner 报 `failed to write serial websocket bytes: broken pipe`。

## 修改

- 将 serial websocket reader 写入本地 runner bridge 的 binary/text 路径收敛到 `write_bridge_bytes`。
- 当本地 runner consumer 已经关闭导致 `write_all` 或 `flush` 返回 `BrokenPipe` 时，将其视为本地终端已经结束读取，正常退出 reader task。
- 其他写入错误仍继续向外返回，writer task 发往 websocket server 的错误也保持原有严格传播。
- 添加回归测试覆盖本地 consumer 提前关闭后 reader task/shutdown 正常完成的场景。

## 验证

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p ostool serial_stream -- --nocapture`
- `cargo test -p ostool -- --nocapture`
- `cargo test -p ostool --all-features -- --nocapture`
- `cargo clippy -p ostool --all-targets --all-features -- -D warnings`
- `cargo build --target x86_64-unknown-linux-gnu --all-features`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features`
- `cargo test --target x86_64-unknown-linux-gnu --all-features -- --nocapture`

未做真实硬件板卡验证；本 PR 只修复 ostool 本地 serial bridge 关闭路径。
