### PR TITLE
feat(build): expose Cargo build artifact output

### DIFF
--- a/ostool/src/build/mod.rs
+++ b/ostool/src/build/mod.rs
@@ -49,6 +49,42 @@ pub mod config;
 
 pub mod someboot;
 
+/// Executable artifact information produced by a Cargo build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CargoBuildOutput {
+    elf_path: PathBuf,
+    cargo_artifact_dir: PathBuf,
+}
+
+impl CargoBuildOutput {
+    fn new(elf_path: PathBuf, cargo_artifact_dir: PathBuf) -> Self {
+        Self {
+            elf_path,
+            cargo_artifact_dir,
+        }
+    }
+
+    /// Path to the executable ELF reported by Cargo.
+    pub fn elf_path(&self) -> &Path {
+        &self.elf_path
+    }
+
+    /// Directory containing the executable artifact reported by Cargo.
+    pub fn cargo_artifact_dir(&self) -> &Path {
+        &self.cargo_artifact_dir
+    }
+}
+
+impl From<&CargoBuildOutcome> for CargoBuildOutput {
+    fn from(outcome: &CargoBuildOutcome) -> Self {
+        let resolved = outcome.resolved_artifact();
+        Self::new(
+            resolved.elf_path().to_path_buf(),
+            resolved.cargo_artifact_dir().to_path_buf(),
+        )
+    }
+}
+
 /// Parameters for running a built Cargo artifact in QEMU.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CargoQemuRunnerArgs {
@@ -247,14 +283,14 @@ pub(crate) fn build_custom(invocation: &mut Invocation, config: &Custom) -> anyh
     Ok(())
 }
 
-/// Builds the project using Cargo.
+/// Builds the project using Cargo and returns the executable artifact selected from Cargo output.
 ///
 /// `config_path` is the optional `.build.toml` source path for `config`.
 pub async fn cargo_build(
     invocation: &mut Invocation,
     config: &Cargo,
     config_path: Option<&Path>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<CargoBuildOutput> {
     activate_build_config(
         invocation,
         &BuildConfig {
@@ -267,7 +303,7 @@ pub async fn cargo_build(
     let outcome = CargoBuildPipeline::build(input, config).execute().await?;
     apply_cargo_build_outcome(invocation, config, &outcome, false, debug)?;
     run_cargo_post_build_cmds(invocation, config)?;
-    Ok(())
+    Ok(CargoBuildOutput::from(&outcome))
 }
 
 /// Builds or imports the configured artifact and prepares the runtime outputs.
@@ -421,7 +457,7 @@ fn run_cargo_post_build_cmds(invocation: &mut Invocation, config: &Cargo) -> any
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{fs, path::PathBuf};
 
     use crate::{
         build::{
@@ -434,8 +470,8 @@ mod tests {
     };
 
     use super::{
-        CargoSelector, activate_build_config, activate_build_context, apply_cargo_build_outcome,
-        build_with_config,
+        CargoBuildOutput, CargoSelector, activate_build_config, activate_build_context,
+        apply_cargo_build_outcome, build_with_config,
     };
 
     #[test]
@@ -499,6 +535,21 @@ mod tests {
         );
         assert!(invocation.runtime_artifacts().debug_artifacts().is_empty());
         assert!(invocation.runtime_arch().is_some());
+    }
+
+    #[test]
+    fn cargo_build_output_exposes_resolved_artifact_paths() {
+        let cargo_artifact_dir = PathBuf::from("target/aarch64/release");
+        let elf_path = cargo_artifact_dir.join("kernel");
+        let outcome = CargoBuildOutcome::new(ResolvedCargoArtifact::new(
+            elf_path.clone(),
+            cargo_artifact_dir.clone(),
+        ));
+
+        let output = CargoBuildOutput::from(&outcome);
+
+        assert_eq!(output.elf_path(), elf_path.as_path());
+        assert_eq!(output.cargo_artifact_dir(), cargo_artifact_dir.as_path());
     }
 
     #[tokio::test]

--- a/ostool/tests/ui/pass_module_level_apis.rs
+++ b/ostool/tests/ui/pass_module_level_apis.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use ostool::{
     board::{self, config::BoardRunConfig},
     build::{
-        self, CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs,
+        self, CargoBuildOutput, CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs,
         config::{BuildConfig, BuildSystem, Cargo, Custom},
     },
     invocation::{Invocation, InvocationOptions},
@@ -58,7 +58,8 @@ fn main() {
             build::load_build_config_from_path(&invocation, Path::new(".build.toml"), false)
                 .await;
         let _ = build::build_with_config(&mut invocation, &custom_build, None).await;
-        let _ = build::cargo_build(&mut invocation, &cargo, None).await;
+        let _: anyhow::Result<CargoBuildOutput> =
+            build::cargo_build(&mut invocation, &cargo, None).await;
         let _ = build::cargo_run(&mut invocation, &cargo, None, &qemu_runner).await;
         let _ = build::cargo_run(&mut invocation, &cargo, None, &uboot_runner).await;
 


### PR DESCRIPTION
## 问题

下游调用 `ostool::build::cargo_build` 后只能知道构建成功，无法直接拿到 Cargo JSON 输出中解析出的可执行产物路径。需要使用该路径的调用方只能自行按 `target/<target>/<profile>/<bin>` 规则拼接，容易和 Cargo 实际选择的 bin、profile、target-dir 或后续构建逻辑产生偏差。

## 修改

- 新增 public 类型 `ostool::build::CargoBuildOutput`，暴露：
  - `elf_path()`：Cargo 解析出的可执行 ELF 路径。
  - `cargo_artifact_dir()`：该可执行产物所在目录。
- 新增 `ostool::build::cargo_build_with_output(...) -> anyhow::Result<CargoBuildOutput>`，复用现有 Cargo build pipeline，在完成 runtime artifact 状态更新和 post-build commands 后返回构建产物信息。
- 保留原有 `cargo_build(...) -> anyhow::Result<()>`，改为调用新函数后丢弃返回值，避免破坏现有调用方。
- 更新 public API 编译测试，确认新类型和新函数可被外部使用。

## 设计说明

该接口不改变现有 `cargo_build` 的返回类型，降低兼容性影响；同时输出值从内部 `CargoBuildOutcome` / `ResolvedCargoArtifact` 转换而来，保证下游拿到的路径和 ostool 当前选择、记录的 Cargo artifact 保持一致。

## 验证

- `cargo fmt`
- `cargo test`
