### PR TITLE
ci: run release-plz directly on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,16 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["Quality Check"]
-    branches: [main]
-    types: [completed]
+  push:
+    branches:
+      - main
 
 permissions: {}
 
 jobs:
   release-plz-release:
     name: Release-plz release
-    if: &release_condition ${{ github.repository_owner == 'drivercraft' && github.event.workflow_run.conclusion == 'success' }}
+    if: &release_condition ${{ github.repository_owner == 'drivercraft' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- run the release workflow directly on pushes to main
- remove the workflow_run dependency on Quality Check completion
- keep release-plz's two-job layout and existing permissions/concurrency

## Verification
- python3 YAML parse for .github/workflows/release.yml
- git diff --check