### PR TITLE
fix(ostool): throttle shell init input

### DIFF
--- a/ostool/src/run/httpboot_board.rs
+++ b/ostool/src/run/httpboot_board.rs
@@ -31,7 +31,9 @@ use crate::{
         output_matcher::{
             ByteStreamMatcher, MATCH_DRAIN_DURATION, compile_regexes, print_match_event,
         },
-        shell_init::{SHELL_INIT_DELAY, ShellAutoInitMatcher},
+        shell_init::{
+            SHELL_INIT_CHUNK_DELAY, SHELL_INIT_CHUNK_SIZE, SHELL_INIT_DELAY, ShellAutoInitMatcher,
+        },
         uboot::UbootRunInput,
     },
     sterm::{AsyncTerminal, TerminalConfig},
@@ -385,7 +387,12 @@ where
             if let Some(shell_init) = shell_init.as_mut()
                 && let Some(command) = shell_init.observe_byte(byte)
             {
-                handle.send_after(SHELL_INIT_DELAY, command);
+                handle.send_after_chunks(
+                    SHELL_INIT_DELAY,
+                    command,
+                    SHELL_INIT_CHUNK_SIZE,
+                    SHELL_INIT_CHUNK_DELAY,
+                );
             }
 
             if matcher.should_stop() {

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -58,7 +58,10 @@ use crate::{
         output_matcher::{ByteStreamMatcher, compile_regexes, print_match_event},
         ovmf_prebuilt::{Arch, FileType, Prebuilt, Source},
         qemu_plan::{QemuBootSource, QemuCommandPlanInput, build_qemu_command_plan},
-        shell_init::{SHELL_INIT_DELAY, ShellAutoInitMatcher, normalize_shell_init_config},
+        shell_init::{
+            SHELL_INIT_CHUNK_DELAY, SHELL_INIT_CHUNK_SIZE, SHELL_INIT_DELAY, ShellAutoInitMatcher,
+            normalize_shell_init_config,
+        },
     },
     sterm::{AsyncTerminal, TerminalConfig},
     utils::PathResultExt,
@@ -555,7 +558,12 @@ impl QemuRunner {
                     if let Some(shell_auto_init) = shell_auto_init.as_mut()
                         && let Some(command) = shell_auto_init.observe_byte(byte)
                     {
-                        handle.send_after(SHELL_INIT_DELAY, command);
+                        handle.send_after_chunks(
+                            SHELL_INIT_DELAY,
+                            command,
+                            SHELL_INIT_CHUNK_SIZE,
+                            SHELL_INIT_CHUNK_DELAY,
+                        );
                     }
 
                     if matcher.should_stop() {

--- a/ostool/src/run/shell_init.rs
+++ b/ostool/src/run/shell_init.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use anyhow::{Result, bail};
 
 pub(crate) const SHELL_INIT_DELAY: Duration = Duration::from_millis(100);
+pub(crate) const SHELL_INIT_CHUNK_SIZE: usize = 64;
+pub(crate) const SHELL_INIT_CHUNK_DELAY: Duration = Duration::from_millis(2);
 
 pub(crate) fn normalize_shell_init_config(
     shell_prefix: &mut Option<String>,

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -50,7 +50,10 @@ use crate::{
         output_matcher::{
             ByteStreamMatcher, MATCH_DRAIN_DURATION, compile_regexes, print_match_event,
         },
-        shell_init::{SHELL_INIT_DELAY, ShellAutoInitMatcher, normalize_shell_init_config},
+        shell_init::{
+            SHELL_INIT_CHUNK_DELAY, SHELL_INIT_CHUNK_SIZE, SHELL_INIT_DELAY, ShellAutoInitMatcher,
+            normalize_shell_init_config,
+        },
         tftp,
     },
     sterm::{AsyncTerminal, TerminalConfig},
@@ -1270,7 +1273,12 @@ where
                 if let Some(shell_init) = shell_init.as_mut()
                     && let Some(command) = shell_init.observe_byte(byte)
                 {
-                    h.send_after(SHELL_INIT_DELAY, command);
+                    h.send_after_chunks(
+                        SHELL_INIT_DELAY,
+                        command,
+                        SHELL_INIT_CHUNK_SIZE,
+                        SHELL_INIT_CHUNK_DELAY,
+                    );
                 }
 
                 if matcher.should_stop() {

--- a/ostool/src/sterm/mod.rs
+++ b/ostool/src/sterm/mod.rs
@@ -321,6 +321,29 @@ impl TerminalHandle {
         });
     }
 
+    pub fn send_after_chunks(
+        &self,
+        duration: Duration,
+        bytes: Vec<u8>,
+        chunk_size: usize,
+        chunk_delay: Duration,
+    ) {
+        let handle = self.clone();
+        let chunk_size = chunk_size.max(1);
+        tokio::spawn(async move {
+            tokio::time::sleep(duration).await;
+            for chunk in bytes.chunks(chunk_size) {
+                if !handle.is_running() {
+                    break;
+                }
+                if handle.send(chunk.to_vec()).is_err() {
+                    break;
+                }
+                tokio::time::sleep(chunk_delay).await;
+            }
+        });
+    }
+
     pub fn is_running(&self) -> bool {
         self.inner.running.load(Ordering::Acquire)
     }
@@ -840,6 +863,23 @@ mod tests {
         assert!(!handle.timed_out());
         assert!(handle.stop_deadline().is_none());
         assert!(handle.timeout_deadline().is_some());
+    }
+
+    #[tokio::test]
+    async fn send_after_chunks_splits_long_terminal_input() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let handle = TerminalHandle::new(tx);
+
+        handle.send_after_chunks(
+            Duration::ZERO,
+            b"abcdef".to_vec(),
+            2,
+            Duration::from_millis(1),
+        );
+
+        assert_eq!(rx.recv().await.unwrap(), b"ab");
+        assert_eq!(rx.recv().await.unwrap(), b"cd");
+        assert_eq!(rx.recv().await.unwrap(), b"ef");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 问题

`rcore-os/tgoskits#1391` 中的 Starry x86_64 `tty-console-input-burst` CI 超时并不是单个测试超时时间不足。失败日志显示系统已经进入 Starry shell，并开始接收 `shell_init_cmd` heredoc，但后续 EOF 和执行命令没有稳定完成。

根因在 ostool 的自动 shell 初始化输入路径：检测到 `shell_prefix` 后，当前实现会把整个 `shell_init_cmd` 作为一个大块一次性写入 QEMU/serial stdin。长 heredoc 会形成输入 burst，容易超过 guest console/TTY 的处理窗口，导致 shell 初始化命令卡在半途。

## 修改

- 为 `TerminalHandle` 增加 `send_after_chunks`，支持延迟后按固定大小拆分输入，并在 chunk 间短暂让出。
- 将 QEMU、HTTPBoot board、U-Boot 的自动 `shell_init_cmd` 注入改成 64 字节一块、块间 2ms 发送。
- 保持普通交互输入和 boot offer 等其他自动发送路径不变。
- 增加单元测试，覆盖长输入会被拆分发送。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features`
- `cargo test --target x86_64-unknown-linux-gnu -- --nocapture`
- 在 tgoskits 中通过 `[patch.crates-io]` 指向本地 ostool 后验证原失败用例：
  `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/tty-console-input-burst`
  结果：`PASS tty-console-input-burst`，`all starry qemu tests passed`。

Fixes rcore-os/tgoskits#1391
