### PR TITLE
fix(ostool): support LoongArch U-Boot board boot

### DIFF
--- a/fitimage/src/fit/standard_dt_builder.rs
+++ b/fitimage/src/fit/standard_dt_builder.rs
@@ -6,6 +6,9 @@ use crate::error::Result;
 use crate::fit::config::{ComponentConfig, FitImageConfig};
 use crate::fit::{FdtHeader, FdtToken, FdtTokenUtils, MemReserveEntry, StringTable};
 
+const FDT_DATA_ALIGNMENT: usize = 8;
+const PROPERTY_PREFIX_SIZE: usize = 3 * size_of::<u32>();
+
 /// Standard FDT builder that creates U-Boot compatible FIT images
 pub struct StandardFdtBuilder {
     /// FDT header
@@ -265,7 +268,7 @@ impl StandardFdtBuilder {
             self.add_property_u64("load", load_addr)?;
         }
 
-        self.add_property_data("data", &component.data)?;
+        self.add_fdt_property_data("data", &component.data)?;
 
         // Add hash nodes to match mkimage standard
         // self.add_hash_nodes(&component.data)?;
@@ -357,6 +360,23 @@ impl StandardFdtBuilder {
         FdtTokenUtils::write_prop_header(&mut self.struct_buffer, data.len() as u32, name_offset)?;
         FdtTokenUtils::write_prop_data(&mut self.struct_buffer, data)?;
         Ok(())
+    }
+
+    /// Add an FDT payload at the alignment required for a nested devicetree blob.
+    fn add_fdt_property_data(&mut self, name: &str, data: &[u8]) -> Result<()> {
+        self.align_fdt_data();
+        self.add_property_data(name, data)
+    }
+
+    fn align_fdt_data(&mut self) {
+        let data_offset = FdtHeader::size()
+            + self.mem_reserve.len() * MemReserveEntry::size()
+            + self.struct_buffer.len()
+            + PROPERTY_PREFIX_SIZE;
+
+        if !data_offset.is_multiple_of(FDT_DATA_ALIGNMENT) {
+            FdtToken::Nop.write_to_buffer(&mut self.struct_buffer);
+        }
     }
 
     /// Finalize and return the complete FDT
@@ -489,5 +509,47 @@ mod tests {
         // Should be valid
         assert!(!fdt_data.is_empty());
         assert_eq!(&fdt_data[0..4], b"\xd0\x0d\xfe\xed");
+    }
+
+    #[test]
+    fn only_fdt_component_data_is_eight_byte_aligned() {
+        let kernel_data = vec![0xa5; 17];
+        let fdt_data = vec![0x5a; 19];
+        let config = FitImageConfig::new("Aligned FIT")
+            .with_kernel(
+                ComponentConfig::new("kernel", kernel_data.clone())
+                    .with_description("Kernel")
+                    .with_type("kernel")
+                    .with_arch("loongarch")
+                    .with_os("linux")
+                    .with_compression(false)
+                    .with_load_address(0x9000_0000_9800_0000)
+                    .with_entry_point(0x9000_0000_9800_0000),
+            )
+            .with_fdt(
+                ComponentConfig::new("fdt", fdt_data.clone())
+                    .with_description("FDT")
+                    .with_type("flat_dt")
+                    .with_arch("loongarch"),
+            );
+
+        let mut builder = StandardFdtBuilder::new().unwrap();
+        builder.build_fit_tree(&config).unwrap();
+        let fit_data = builder.finalize().unwrap();
+        let kernel_offset = fit_data
+            .windows(kernel_data.len())
+            .position(|window| window == kernel_data)
+            .unwrap();
+        let fdt_offset = fit_data
+            .windows(fdt_data.len())
+            .position(|window| window == fdt_data)
+            .unwrap();
+
+        assert_eq!(
+            kernel_offset % 8,
+            4,
+            "kernel data offset: {kernel_offset:#x}"
+        );
+        assert_eq!(fdt_offset % 8, 0, "FDT data offset: {fdt_offset:#x}");
     }
 }

--- a/ostool/src/boot/fit.rs
+++ b/ostool/src/boot/fit.rs
@@ -16,6 +16,9 @@ const FDT_COMPONENT_NAME: &str = "fdt";
 const DEFAULT_CONFIG_NAME: &str = "config-ostool";
 const FIT_DESCRIPTION: &str = "Various kernels, ramdisks and FDT blobs";
 const FIT_IMAGE_NAME: &str = "image.fit";
+const LOONGARCH_IMAGE_MAGIC: &[u8] = b"MZ";
+const LOONGARCH_IMAGE_ENTRY_OFFSET: usize = 8;
+const LOONGARCH_IMAGE_LOAD_OFFSET: usize = 24;
 
 mod errors {
     pub const KERNEL_READ_ERROR: &str = "读取 kernel 文件失败";
@@ -60,6 +63,16 @@ pub(crate) async fn generate_fit_image(input: FitInput) -> anyhow::Result<Genera
         Byte::from(kernel_data.len())
     );
 
+    let kernel_entry_addr = resolve_kernel_entry_addr(
+        input.arch,
+        &kernel_data,
+        input.kernel_load_addr,
+        input.kernel_entry_addr,
+    )?;
+    if kernel_entry_addr != input.kernel_entry_addr {
+        info!("resolved LoongArch kernel entry: {kernel_entry_addr:#x}");
+    }
+
     let arch_name = fit_arch_name(input.arch)?;
     let dtb_data = if let Some(dtb_path) = &input.dtb_path {
         let data = fs::read(dtb_path)
@@ -81,7 +94,7 @@ pub(crate) async fn generate_fit_image(input: FitInput) -> anyhow::Result<Genera
         kernel_data,
         dtb_data,
         input.kernel_load_addr,
-        input.kernel_entry_addr,
+        kernel_entry_addr,
         input.fdt_load_addr,
     );
 
@@ -105,10 +118,48 @@ pub(crate) fn fit_arch_name(arch: Architecture) -> anyhow::Result<&'static str> 
     match arch {
         Architecture::Aarch64 => Ok("arm64"),
         Architecture::Arm => Ok("arm"),
-        Architecture::LoongArch64 => Ok("loongarch64"),
+        Architecture::LoongArch64 => Ok("loongarch"),
         Architecture::Riscv64 => Ok("riscv"),
         other => anyhow::bail!("unsupported architecture for FIT image generation: {other:?}"),
     }
+}
+
+fn resolve_kernel_entry_addr(
+    arch: Architecture,
+    kernel_data: &[u8],
+    kernel_load_addr: u64,
+    fallback_entry_addr: u64,
+) -> anyhow::Result<u64> {
+    if arch != Architecture::LoongArch64 || !kernel_data.starts_with(LOONGARCH_IMAGE_MAGIC) {
+        return Ok(fallback_entry_addr);
+    }
+
+    let image_entry = read_image_header_u64(kernel_data, LOONGARCH_IMAGE_ENTRY_OFFSET)?;
+    let image_load_addr = read_image_header_u64(kernel_data, LOONGARCH_IMAGE_LOAD_OFFSET)?;
+    let entry_offset = image_entry.checked_sub(image_load_addr).ok_or_else(|| {
+        anyhow!(
+            "invalid LoongArch image header: entry {image_entry:#x} precedes load address {image_load_addr:#x}"
+        )
+    })?;
+    if entry_offset >= kernel_data.len() as u64 {
+        anyhow::bail!(
+            "invalid LoongArch image header: entry offset {entry_offset:#x} exceeds image size {:#x}",
+            kernel_data.len()
+        );
+    }
+
+    kernel_load_addr
+        .checked_add(entry_offset)
+        .ok_or_else(|| anyhow!("LoongArch kernel entry address overflow"))
+}
+
+fn read_image_header_u64(kernel_data: &[u8], offset: usize) -> anyhow::Result<u64> {
+    let bytes = kernel_data
+        .get(offset..offset + size_of::<u64>())
+        .ok_or_else(|| anyhow!("truncated LoongArch image header at offset {offset:#x}"))?;
+    let bytes = <[u8; size_of::<u64>()]>::try_from(bytes)
+        .map_err(|_| anyhow!("invalid LoongArch image header field at offset {offset:#x}"))?;
+    Ok(u64::from_le_bytes(bytes))
 }
 
 fn default_output_path(kernel_path: &Path) -> anyhow::Result<PathBuf> {
@@ -167,7 +218,10 @@ fn build_default_fit_config(
 
 #[cfg(test)]
 mod tests {
-    use super::{FitInput, build_default_fit_config, default_output_path, fit_arch_name};
+    use super::{
+        FitInput, build_default_fit_config, default_output_path, fit_arch_name,
+        resolve_kernel_entry_addr,
+    };
     use object::Architecture;
 
     #[test]
@@ -176,7 +230,7 @@ mod tests {
         assert_eq!(fit_arch_name(Architecture::Arm).unwrap(), "arm");
         assert_eq!(
             fit_arch_name(Architecture::LoongArch64).unwrap(),
-            "loongarch64"
+            "loongarch"
         );
         assert_eq!(fit_arch_name(Architecture::Riscv64).unwrap(), "riscv");
     }
@@ -189,6 +243,24 @@ mod tests {
             err.to_string()
                 .contains("unsupported architecture for FIT image generation: X86_64")
         );
+    }
+
+    #[test]
+    fn resolves_loongarch_linux_image_entry_from_header() {
+        let mut kernel_data = vec![0_u8; 0x40_0000];
+        kernel_data[..2].copy_from_slice(b"MZ");
+        kernel_data[8..16].copy_from_slice(&0x5c_8b40_u64.to_le_bytes());
+        kernel_data[24..32].copy_from_slice(&0x20_0000_u64.to_le_bytes());
+
+        let entry = resolve_kernel_entry_addr(
+            Architecture::LoongArch64,
+            &kernel_data,
+            0x9000_0000_9800_0000,
+            0x9000_0000_9800_0000,
+        )
+        .unwrap();
+
+        assert_eq!(entry, 0x9000_0000_983c_8b40);
     }
 
     #[test]

--- a/ostool/tests/ui/fail_cargo_pipeline.rs
+++ b/ostool/tests/ui/fail_cargo_pipeline.rs
@@ -1,5 +1,3 @@
-use ostool::build::cargo_pipeline::CargoBuildPipeline;
+use ostool::build::cargo_pipeline as _;
 
-fn main() {
-    let _ = core::mem::size_of::<CargoBuildPipeline<'static>>();
-}
+fn main() {}

--- a/ostool/tests/ui/fail_cargo_pipeline.stderr
+++ b/ostool/tests/ui/fail_cargo_pipeline.stderr
@@ -1,7 +1,7 @@
 error[E0603]: module `cargo_pipeline` is private
  --> tests/ui/fail_cargo_pipeline.rs:1:20
   |
-1 | use ostool::build::cargo_pipeline::CargoBuildPipeline;
+1 | use ostool::build::cargo_pipeline as _;
   |                    ^^^^^^^^^^^^^^ private module
   |
 note: the module `cargo_pipeline` is defined here


### PR DESCRIPTION
## 问题

通过 ostool 为 LoongArch 开发板生成 U-Boot FIT 镜像时，存在以下兼容性问题：

- FIT 中使用的 LoongArch 架构名称与 U-Boot 约定不一致。
- LoongArch Linux Image 被加载到新的运行地址后，FIT 入口地址没有根据镜像头中的入口偏移重新计算。
- FIT 内嵌 DTB 的数据地址可能不满足 DTB 所需的 8 字节对齐。

这些问题可能导致 U-Boot 无法正确识别镜像，或者在加载 DTB、跳转到内核入口时触发异常。

## 修改内容

- 将 LoongArch FIT 架构名称由 `loongarch64` 调整为 U-Boot 使用的 `loongarch`。
- 解析 LoongArch Linux Image 的 MZ 镜像头：
  - 读取链接入口地址。
  - 读取链接加载地址。
  - 根据入口偏移计算重定位后的实际入口地址。
- 仅对 FIT 中的 DTB payload 做 8 字节对齐：
  - 使用合法的 `FDT_NOP` 调整 DTB 数据偏移。
  - 不改变 kernel 和 ramdisk 的原有布局。
- 添加 LoongArch 入口地址计算和 DTB 对齐回归测试。

## 实现逻辑

LoongArch Image 被加载到不同地址时，实际入口地址按以下公式计算：

```
actual_entry = runtime_load + linked_entry - linked_load
```

该处理只对带有 MZ Image 头的 LoongArch 镜像生效，其他架构继续使用原有入口地址。

DTB payload 单独按 8 字节对齐，以满足 DTB 传递要求，同时避免对其他 FIT 组件造成不必要的布局变化。
