### PR TITLE
fix(ci): avoid missing pnpm cache in release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,6 @@ jobs:
         uses: actions/setup-node@v6.3.0
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: ostool-server/webui/pnpm-lock.yaml
 
       - name: Run release-plz
         uses: release-plz/action@v0.5


### PR DESCRIPTION
## Summary

- remove pnpm caching from the shared `actions/setup-node` step in the Release workflow
- keep the existing Node.js and pnpm setup available for release packaging

## Root cause

The release-plz steps completed successfully, but both jobs failed during `Post Setup Node.js`. The workflow configured pnpm caching without running pnpm in release-PR-only executions, so the expected store directory did not exist and `setup-node` failed while saving the cache.

## Impact

Release and release-PR jobs no longer fail during post-job cleanup when no pnpm store was created.

## Validation

- `git diff --check`
- local assertions confirm the cache fields are removed while the Node.js setup and YAML anchor reuse remain intact

`actionlint` was not available in the local environment.