### PR TITLE
feat(board): share files over session HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,6 +2637,7 @@ dependencies = [
  "trybuild",
  "uboot-shell",
  "ureq",
+ "url",
 ]
 
 [[package]]
@@ -2673,6 +2674,7 @@ dependencies = [
  "toml",
  "tower",
  "tower-http",
+ "url",
  "uuid",
 ]
 
@@ -4668,6 +4670,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 
 toml = "1.0"
+url = {version = "2", features = ["serde"]}
 
 httpboot-protocol = { version = "0.1", path = "./httpboot-protocol" }
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,13 @@ ostool board config
 
 `server` 应使用包含 `http://` 或 `https://` 的完整 URL；可选的 `port` 会覆盖 URL 中的端口。为兼容旧的局域网配置，裸 IPv4 或 IPv6 地址会自动补为 `http://`。基线版本写出的 `server_ip` / `port` 也会在读取时迁移为 `server` / `port`，下一次保存配置时只写新格式；无 scheme 的主机名不支持。项目级 `.board.toml` 中的 `server` / `port` 仍可用于 `ostool board run`，其优先级低于命令行参数，高于全局配置。
 
+`.board.toml` 可以用 `session_files` 声明相对于配置文件目录的共享文件。调用方通过
+`BoardRunRequest::with_session_files` 提供该目录，ostool 会在 board session
+建立后按原相对路径上传，并在 `shell_init_cmd` 中展开
+`${boardServerIp}`、`${boardServerHttpBaseUrl}` 和
+`${sessionFile:<relative-path>}`。绝对路径、`..`、符号链接逃逸、重复路径及缺失
+文件都会在运行前被拒绝；接口不提供 alias 或上传改名。
+
 ### 公网开发板认证
 
 局域网直接连接 `ostool-server` 时保留上述匿名 HTTP 配置。公网认证网关使用完整 HTTPS 地址：

--- a/docs/api.md
+++ b/docs/api.md
@@ -309,11 +309,12 @@ GET /api/v1/sessions/{session_id}/boot-profile
   },
   "server_ip": "192.168.1.2",
   "netmask": "255.255.255.0",
-  "interface": "eth0"
+  "interface": "eth0",
+  "http_base_url": "http://192.168.1.2:2999/"
 }
 ```
 
-`boot.kind` 可为 `uboot`、`pxe` 或 `httpboot`（客户端也接受别名 `uefi_http`）。`pxe` 的对象仅含可选 `notes`；`httpboot` 的对象含可选 `boot_arch`（`x86_64`、`aarch64`、`loongarch64`、`riscv64` 或 `other`）和 `mac`。顶层 `server_ip`、`netmask`、`interface` 均可为 `null`。
+`boot.kind` 可为 `uboot`、`pxe` 或 `httpboot`（客户端也接受别名 `uefi_http`）。`pxe` 的对象仅含可选 `notes`；`httpboot` 的对象含可选 `boot_arch`（`x86_64`、`aarch64`、`loongarch64`、`riscv64` 或 `other`）和 `mac`。顶层 `server_ip`、`netmask`、`interface`、`http_base_url` 均可为 `null`。`server_ip` 和 `http_base_url` 使用板端可访问的网络地址，不一定等于管理网地址。
 
 ### 获取串口状态
 
@@ -418,12 +419,14 @@ X-File-Path: <relative_path>
   "filename": "Image",
   "relative_path": "boot/Image",
   "tftp_url": "tftp://192.168.1.2/boot/Image",
+  "http_url": "http://192.168.1.2:2999/share/sessions/.../boot/Image",
   "size": 1048576,
   "uploaded_at": "2026-07-20T02:00:00Z"
 }
 ```
 
-`tftp_url` 可为 `null`。
+`tftp_url` 可为 `null`；`http_url` 使用板端可访问的服务地址。会话文件 HTTP
+共享不依赖 TFTP 是否启用。
 
 ### 列出、查询和删除会话文件
 
@@ -436,6 +439,18 @@ DELETE /api/v1/sessions/{session_id}/files/{path}
 三个请求均没有请求体。前两个请求成功返回 `200 OK`：列表接口返回文件对象数组，单文件接口返回一个文件对象，格式与上传会话文件的成功响应相同。删除成功返回 `204 No Content`。`path` 必须是相对路径。
 
 历史上传路径 `PUT /api/v1/sessions/{session_id}/files/{path}` 被明确拒绝并返回 `404`；上传必须使用前述 `PUT /files` 加 `X-File-Path` Header 的形式。
+
+### 下载共享会话文件
+
+```http
+GET /share/sessions/{session_id}/{relative_path}
+Range: bytes=<start>-<end>  # 可选
+```
+
+该端点适用于所有 boot mode，与 TFTP 和 HTTP Boot 开关无关。无 Range 时返回
+`200 OK` 和完整文件；合法单段 Range 返回 `206 Partial Content`。URL 仅在 session
+活动期间有效，session 释放、超时或进入 releasing 状态后返回 `404`，对应文件随
+session 清理。
 
 ### 上传 HTTP Boot 文件
 

--- a/ostool-server/Cargo.toml
+++ b/ostool-server/Cargo.toml
@@ -49,6 +49,7 @@ tokio-modbus = {version = "0.17.0", default-features = false, features = ["rtu"]
 tokio-serial = "5.4"
 toml = {workspace = true}
 tower-http = {version = "0.6", features = ["fs"]}
+url = {workspace = true}
 uuid = {version = "1", features = ["serde", "v4"]}
 
 [dev-dependencies]

--- a/ostool-server/README.md
+++ b/ostool-server/README.md
@@ -99,6 +99,12 @@ HTTP Boot is enabled by default. Uploaded UEFI HTTP Boot artifacts reuse the
 existing session file storage and lifecycle, so files are scoped to the active
 board session and are cleaned up with that session.
 
+Every active board session also exposes uploaded files through
+`GET /share/sessions/{session_id}/{relative_path}`. This endpoint supports full
+and single-range downloads for every boot mode and remains available when TFTP
+is disabled. Upload responses include a board-reachable `http_url`; both the
+file and URL expire when the session is released or times out.
+
 For boards using the UEFI HTTP Boot loader, configure the board boot profile
 with `kind = "httpboot"` and, when needed, `boot_arch`. The server uses the
 allocated board session and that board's serial configuration to send the boot

--- a/ostool-server/src/api/models.rs
+++ b/ostool-server/src/api/models.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 pub use httpboot_protocol::KernelPublishResponse;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::{
     config::{
@@ -52,7 +53,7 @@ pub struct SessionDetailResponse {
     pub board: BoardConfig,
     pub serial_available: bool,
     pub serial_connected: bool,
-    pub files: Vec<FileResponse>,
+    pub files: Vec<SharedSessionFileResponse>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -124,20 +125,25 @@ pub struct NetworkInterfaceSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FileResponse {
+pub struct SharedSessionFileResponse {
     pub filename: String,
     pub relative_path: String,
-    pub tftp_url: Option<String>,
+    pub tftp_url: Option<Url>,
+    pub http_url: Option<Url>,
     pub size: u64,
     pub uploaded_at: DateTime<Utc>,
 }
 
-impl FileResponse {
-    pub fn from_file(file: TftpFileRef, tftp_url: Option<String>) -> Self {
+#[deprecated(note = "use SharedSessionFileResponse")]
+pub type FileResponse = SharedSessionFileResponse;
+
+impl SharedSessionFileResponse {
+    pub fn from_file(file: TftpFileRef, tftp_url: Option<Url>, http_url: Option<Url>) -> Self {
         Self {
             filename: file.filename,
             relative_path: file.relative_path,
             tftp_url,
+            http_url,
             size: file.size,
             uploaded_at: file.uploaded_at,
         }
@@ -148,13 +154,13 @@ impl FileResponse {
 pub struct HttpBootFileResponse {
     pub filename: String,
     pub relative_path: String,
-    pub http_url: String,
+    pub http_url: Url,
     pub size: u64,
     pub uploaded_at: DateTime<Utc>,
 }
 
 impl HttpBootFileResponse {
-    pub fn from_file(file: TftpFileRef, http_url: String) -> Self {
+    pub fn from_file(file: TftpFileRef, http_url: Url) -> Self {
         Self {
             filename: file.filename,
             relative_path: file.relative_path,
@@ -172,7 +178,13 @@ pub struct TftpSessionResponse {
     pub server_ip: Option<String>,
     pub netmask: Option<String>,
     pub writable: bool,
-    pub files: Vec<FileResponse>,
+    pub files: Vec<SharedSessionFileResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatResponse {
+    pub session_id: String,
+    pub lease_expires_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,7 +192,7 @@ pub struct SessionDtbResponse {
     pub dtb_name: Option<String>,
     pub relative_path: Option<String>,
     pub session_file_path: Option<String>,
-    pub tftp_url: Option<String>,
+    pub tftp_url: Option<Url>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -233,6 +245,7 @@ pub struct BootProfileResponse {
     pub server_ip: Option<String>,
     pub netmask: Option<String>,
     pub interface: Option<String>,
+    pub http_base_url: Option<Url>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ostool-server/src/api/router.rs
+++ b/ostool-server/src/api/router.rs
@@ -11,13 +11,13 @@ use axum::{
 use futures_util::future::join_all;
 use httpboot_protocol::{BootArch, ImageFormat};
 use mime_guess::from_path;
-use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tokio::{
     fs::{self, File},
     io::{AsyncReadExt, AsyncSeekExt, SeekFrom},
 };
+use url::Url;
 
 use crate::{
     api::{
@@ -28,9 +28,10 @@ use crate::{
             AdminSessionsResponse, AdminTftpConfigResponse, AdminTftpStatusResponse,
             BoardPowerAction, BoardPowerStatusResponse, BoardRuntimeStatusResponse,
             BoardTypeSummary, BootProfileResponse, CreateSessionRequest, DtbFileResponse,
-            FileResponse, HttpBootFileResponse, KernelPublishResponse, NetworkInterfaceSummary,
-            SerialPortSummary, SerialStatusResponse, SessionCreatedResponse, SessionDetailResponse,
-            SessionDtbResponse, TftpSessionResponse, UpdateServerConfigRequest,
+            HeartbeatResponse, HttpBootFileResponse, KernelPublishResponse,
+            NetworkInterfaceSummary, SerialPortSummary, SerialStatusResponse,
+            SessionCreatedResponse, SessionDetailResponse, SessionDtbResponse,
+            SharedSessionFileResponse, TftpSessionResponse, UpdateServerConfigRequest,
         },
     },
     board_pool::BoardAllocationStatus,
@@ -75,6 +76,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/boot/sessions/{session_id}/{*path}",
             get(get_http_boot_file),
+        )
+        .route(
+            "/share/sessions/{session_id}/{*path}",
+            get(get_shared_session_file),
         )
         .route("/api/v1/admin/overview", get(get_admin_overview))
         .route("/api/v1/admin/boards", get(list_boards).post(create_board))
@@ -925,7 +930,7 @@ async fn get_session(
 async fn heartbeat_session(
     Path(session_id): Path<String>,
     State(state): State<AppState>,
-) -> Result<axum::Json<serde_json::Value>, ApiError> {
+) -> Result<axum::Json<HeartbeatResponse>, ApiError> {
     let session = state
         .heartbeat_session(&session_id)
         .await
@@ -937,10 +942,10 @@ async fn heartbeat_session(
                 ApiError::conflict(format!("session `{session_id}` is releasing"))
             }
         })?;
-    Ok(axum::Json(json!({
-        "session_id": session.id,
-        "lease_expires_at": session.expires_at
-    })))
+    Ok(axum::Json(HeartbeatResponse {
+        session_id: session.id,
+        lease_expires_at: session.expires_at,
+    }))
 }
 
 async fn delete_session(
@@ -966,12 +971,20 @@ async fn get_boot_profile(
         .session_board(&session_id)
         .await
         .ok_or_else(|| ApiError::not_found("session board not found"))?;
-    let network = resolved_board_network(&state, &board).await?;
+    let network = resolved_shared_network(&state, &board).await?;
+    let http_base_url = match network
+        .as_ref()
+        .and_then(|network| network.server_ip.as_deref())
+    {
+        Some(server_ip) => Some(shared_http_base_url(&state, server_ip).await?),
+        None => None,
+    };
     Ok(axum::Json(BootProfileResponse {
         boot: boot_profile_with_resolved_network(board.boot, network.as_ref()),
         server_ip: network.as_ref().and_then(|item| item.server_ip.clone()),
         netmask: network.as_ref().and_then(|item| item.netmask.clone()),
         interface: network.as_ref().and_then(|item| item.interface.clone()),
+        http_base_url,
     }))
 }
 
@@ -1143,6 +1156,16 @@ async fn get_http_boot_file(
     read_http_boot_session_file(&state, &session_id, &relative_path, request.headers()).await
 }
 
+async fn get_shared_session_file(
+    Path((session_id, path)): Path<(String, String)>,
+    State(state): State<AppState>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    let relative_path = parse_relative_path(&path)?;
+    active_shared_session_or_404(&state, &session_id).await?;
+    read_session_file_response(&state, &session_id, &relative_path, request.headers()).await
+}
+
 async fn read_http_boot_session_file(
     state: &AppState,
     session_id: &str,
@@ -1153,6 +1176,15 @@ async fn read_http_boot_session_file(
     if !config.http_boot.enabled {
         return Err(ApiError::not_found("HTTP Boot is disabled"));
     }
+    read_session_file_response(state, session_id, relative_path, headers).await
+}
+
+async fn read_session_file_response(
+    state: &AppState,
+    session_id: &str,
+    relative_path: &str,
+    headers: &HeaderMap,
+) -> Result<Response, ApiError> {
     let manager = state.tftp_manager.read().await.clone();
     let file = manager
         .get_session_file(session_id, relative_path)
@@ -1315,7 +1347,7 @@ async fn put_http_boot_kernel(
     let config = state.config.read().await.clone();
     let kernel_response = http_boot_file_response(&config, &session_id, &remote_name, kernel_file)?;
     let response = publish_kernel(KernelPublishInput {
-        kernel_url: kernel_response.http_url,
+        kernel_url: kernel_response.http_url.to_string(),
         kernel_size,
         kernel_sha256: Some(kernel_sha256),
     });
@@ -1368,7 +1400,7 @@ fn optional_header(headers: &HeaderMap, name: &'static str) -> Result<Option<Str
 async fn list_session_files(
     Path(session_id): Path<String>,
     State(state): State<AppState>,
-) -> Result<axum::Json<Vec<FileResponse>>, ApiError> {
+) -> Result<axum::Json<Vec<SharedSessionFileResponse>>, ApiError> {
     let board = state
         .session_board(&session_id)
         .await
@@ -1382,7 +1414,7 @@ async fn put_session_file(
     Path(session_id): Path<String>,
     State(state): State<AppState>,
     request: Request,
-) -> Result<(StatusCode, axum::Json<FileResponse>), ApiError> {
+) -> Result<(StatusCode, axum::Json<SharedSessionFileResponse>), ApiError> {
     let session = state
         .session_state(&session_id)
         .await
@@ -1396,10 +1428,6 @@ async fn put_session_file(
         .session_board(&session_id)
         .await
         .ok_or_else(|| ApiError::not_found("session board not found"))?;
-    if !state.config.read().await.tftp.enabled() {
-        return Err(ApiError::conflict("TFTP provider is disabled"));
-    }
-
     let (_relative_path, file) =
         put_session_file_from_request(&state, &session_id, request, "session file").await?;
     let response = file_response_for_board(&state, &board, file).await?;
@@ -1409,7 +1437,7 @@ async fn put_session_file(
 async fn get_session_file(
     Path((session_id, path)): Path<(String, String)>,
     State(state): State<AppState>,
-) -> Result<axum::Json<FileResponse>, ApiError> {
+) -> Result<axum::Json<SharedSessionFileResponse>, ApiError> {
     let relative_path = parse_relative_path(&path)?;
     let board = state
         .session_board(&session_id)
@@ -1537,7 +1565,7 @@ async fn session_file_responses(
     state: &AppState,
     session_id: &str,
     board: &BoardConfig,
-) -> Result<Vec<FileResponse>, ApiError> {
+) -> Result<Vec<SharedSessionFileResponse>, ApiError> {
     let manager = state.tftp_manager.read().await.clone();
     let files = manager.list_session_files(session_id).await?;
     let mut responses = Vec::with_capacity(files.len());
@@ -1551,12 +1579,20 @@ async fn file_response_for_board(
     state: &AppState,
     board: &BoardConfig,
     file: TftpFileRef,
-) -> Result<FileResponse, ApiError> {
+) -> Result<SharedSessionFileResponse, ApiError> {
     let tftp_url = resolved_board_network(state, board)
         .await?
         .and_then(|network| network.server_ip)
-        .map(|server_ip| format!("tftp://{server_ip}/{}", file.relative_path));
-    Ok(FileResponse::from_file(file, tftp_url))
+        .map(|server_ip| session_tftp_url(&server_ip, &file.relative_path))
+        .transpose()?;
+    let shared_network = resolved_shared_network(state, board).await?;
+    let http_url = match shared_network.and_then(|network| network.server_ip) {
+        Some(server_ip) => Some(shared_http_url(state, &server_ip, &file.relative_path).await?),
+        None => None,
+    };
+    Ok(SharedSessionFileResponse::from_file(
+        file, tftp_url, http_url,
+    ))
 }
 
 async fn run_board_power_action(
@@ -1623,6 +1659,22 @@ async fn active_session_state_or_404(
     Ok(session)
 }
 
+async fn active_shared_session_or_404(
+    state: &AppState,
+    session_id: &str,
+) -> Result<Arc<SessionState>, ApiError> {
+    let session = state
+        .session_state(session_id)
+        .await
+        .ok_or_else(|| ApiError::not_found(format!("session `{session_id}` not found")))?;
+    if session.is_releasing() || session.is_stop_requested() {
+        return Err(ApiError::not_found(format!(
+            "session `{session_id}` not found"
+        )));
+    }
+    Ok(session)
+}
+
 fn ensure_httpboot_board(board: &BoardConfig) -> Result<(), ApiError> {
     if matches!(board.boot, BootConfig::UefiHttp(_)) {
         Ok(())
@@ -1648,34 +1700,32 @@ fn http_boot_url(
     config: &ServerConfig,
     session_id: &str,
     relative_path: &str,
-) -> Result<String, ApiError> {
+) -> Result<Url, ApiError> {
     let relative_path = normalize_relative_path(relative_path)
         .map_err(|err| ApiError::bad_request(err.to_string()))?;
-    let base_url = http_boot_public_base_url(config)?;
-    let base_url = base_url.trim_end_matches('/');
-    Ok(format!(
-        "{base_url}/boot/sessions/{session_id}/{relative_path}"
-    ))
+    let mut url = http_boot_public_base_url(config)?;
+    append_url_path(&mut url, &["boot", "sessions", session_id], &relative_path)?;
+    Ok(url)
 }
 
-fn http_boot_public_base_url(config: &ServerConfig) -> Result<String, ApiError> {
+fn http_boot_public_base_url(config: &ServerConfig) -> Result<Url, ApiError> {
     if let Some(public_base_url) = config.http_boot.public_base_url.as_deref()
         && !public_base_url.trim().is_empty()
     {
-        return Ok(public_base_url.trim().to_string());
+        return Url::parse(public_base_url.trim())
+            .map_err(|err| ApiError::bad_request(format!("invalid HTTP Boot public URL: {err}")));
     }
 
     if let Some(network) = resolve_server_network(config)?
         && let Some(server_ip) = network.server_ip
     {
-        return Ok(format!(
-            "http://{}:{}",
-            server_ip,
-            config.listen_addr.port()
-        ));
+        return server_http_base_url(&server_ip, config.listen_addr.port());
     }
 
-    Ok(format!("http://{}", config.listen_addr))
+    server_http_base_url(
+        &config.listen_addr.ip().to_string(),
+        config.listen_addr.port(),
+    )
 }
 
 fn hex_sha256(bytes: &[u8]) -> String {
@@ -1879,6 +1929,73 @@ async fn resolved_board_network(
     Ok(network)
 }
 
+async fn resolved_shared_network(
+    state: &AppState,
+    board: &BoardConfig,
+) -> Result<Option<ResolvedNetwork>, ApiError> {
+    if let Some(network) = resolved_board_network(state, board).await? {
+        return Ok(Some(network));
+    }
+    let config = state.config.read().await.clone();
+    resolve_server_network(&config)
+}
+
+async fn shared_http_base_url(state: &AppState, server_ip: &str) -> Result<Url, ApiError> {
+    let port = state.config.read().await.listen_addr.port();
+    server_http_base_url(server_ip, port)
+}
+
+fn server_http_base_url(server_ip: &str, port: u16) -> Result<Url, ApiError> {
+    let mut url = Url::parse("http://localhost/")
+        .map_err(|error| ApiError::service_unavailable(error.to_string()))?;
+    url.set_host(Some(server_ip))
+        .map_err(|_| ApiError::service_unavailable("invalid shared HTTP server address"))?;
+    url.set_port(Some(port))
+        .map_err(|_| ApiError::service_unavailable("invalid shared HTTP server port"))?;
+    Ok(url)
+}
+
+fn session_tftp_url(server_ip: &str, relative_path: &str) -> Result<Url, ApiError> {
+    let mut url = Url::parse("tftp://localhost/")
+        .map_err(|error| ApiError::service_unavailable(error.to_string()))?;
+    url.set_host(Some(server_ip))
+        .map_err(|_| ApiError::service_unavailable("invalid TFTP server address"))?;
+    append_url_path(&mut url, &[], relative_path)?;
+    Ok(url)
+}
+
+async fn shared_http_url(
+    state: &AppState,
+    server_ip: &str,
+    stored_relative_path: &str,
+) -> Result<Url, ApiError> {
+    let relative_path = stored_relative_path
+        .split_once("/sessions/")
+        .map(|(_, relative)| relative)
+        .ok_or_else(|| ApiError::service_unavailable("invalid stored session file path"))?;
+    let mut url = shared_http_base_url(state, server_ip).await?;
+    append_url_path(&mut url, &["share", "sessions"], relative_path)?;
+    Ok(url)
+}
+
+fn append_url_path(
+    url: &mut Url,
+    prefix_segments: &[&str],
+    relative_path: &str,
+) -> Result<(), ApiError> {
+    let mut segments = url
+        .path_segments_mut()
+        .map_err(|_| ApiError::service_unavailable("HTTP base URL cannot contain path segments"))?;
+    segments.pop_if_empty();
+    for segment in prefix_segments {
+        segments.push(segment);
+    }
+    for segment in relative_path.split('/') {
+        segments.push(segment);
+    }
+    Ok(())
+}
+
 fn boot_profile_with_resolved_network(
     boot: BootConfig,
     network: Option<&ResolvedNetwork>,
@@ -1999,6 +2116,7 @@ mod tests {
         body::{Body, to_bytes},
         http::{Request, StatusCode, header},
     };
+    use serde::Serialize;
     use serde_json::json;
     #[cfg(unix)]
     use serialport::{SerialPort, TTYPort};
@@ -2016,7 +2134,11 @@ mod tests {
         http_boot_url, mib_to_bytes, resolve_server_network,
     };
     use crate::{
-        api::models::{AdminBoardUpsertRequest, BoardRuntimeStatusResponse, SessionDetailResponse},
+        api::models::{
+            AdminBoardUpsertRequest, BoardRuntimeStatusResponse, BootProfileResponse,
+            CreateSessionRequest, SessionCreatedResponse, SessionDetailResponse,
+            SharedSessionFileResponse,
+        },
         build_app_state,
         config::{
             BoardConfig, BootConfig, BuiltinTftpConfig, CustomPowerManagement,
@@ -2060,25 +2182,30 @@ mod tests {
     }
 
     async fn test_router() -> Router {
+        test_router_with_config(|_| {}).await
+    }
+
+    async fn test_router_with_config(update: impl FnOnce(&mut ServerConfig)) -> Router {
         let temp = tempdir().unwrap();
         let root = temp.path().to_path_buf();
         std::mem::forget(temp);
         let config_path = root.join(".ostool-server.toml");
-        let config = test_server_config(&root);
+        let mut config = test_server_config(&root);
+        update(&mut config);
         let manager: Arc<dyn TftpManager> = build_tftp_manager(&config.tftp);
         let state = build_app_state(config_path, config, manager).await.unwrap();
         state.ensure_data_dirs().await.unwrap();
         build_router(state)
     }
 
-    async fn create_board(app: &Router, request: serde_json::Value) -> StatusCode {
+    async fn create_board(app: &Router, request: impl Serialize) -> StatusCode {
         app.clone()
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/api/v1/admin/boards")
                     .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(request.to_string()))
+                    .body(Body::from(serde_json::to_vec(&request).unwrap()))
                     .unwrap(),
             )
             .await
@@ -2087,6 +2214,11 @@ mod tests {
     }
 
     async fn create_session(app: &Router, board_type: &str) -> String {
+        let request = CreateSessionRequest {
+            board_type: board_type.to_string(),
+            required_tags: Vec::new(),
+            client_name: Some("test".to_string()),
+        };
         let response = app
             .clone()
             .oneshot(
@@ -2094,22 +2226,15 @@ mod tests {
                     .method("POST")
                     .uri("/api/v1/sessions")
                     .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        json!({
-                            "board_type": board_type,
-                            "required_tags": [],
-                            "client_name": "test",
-                        })
-                        .to_string(),
-                    ))
+                    .body(Body::from(serde_json::to_vec(&request).unwrap()))
                     .unwrap(),
             )
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::CREATED);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        value["session_id"].as_str().unwrap().to_string()
+        let response: SessionCreatedResponse = serde_json::from_slice(&body).unwrap();
+        response.session_id
     }
 
     async fn upload_dtb(app: &Router, name: &str, body: &'static str) -> StatusCode {
@@ -2324,7 +2449,7 @@ mod tests {
 
         let url = http_boot_url(&config, "asus-1", "kernel.bin").unwrap();
         assert_eq!(
-            url,
+            url.as_str(),
             "http://10.3.10.192:2999/boot/sessions/asus-1/kernel.bin"
         );
     }
@@ -2339,7 +2464,10 @@ mod tests {
         config.http_boot.public_base_url = None;
 
         let url = http_boot_url(&config, "asus-1", "kernel.elf").unwrap();
-        assert_eq!(url, "http://127.0.0.1:2999/boot/sessions/asus-1/kernel.elf");
+        assert_eq!(
+            url.as_str(),
+            "http://127.0.0.1:2999/boot/sessions/asus-1/kernel.elf"
+        );
     }
 
     #[test]
@@ -3702,6 +3830,144 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn shared_session_http_works_without_tftp_and_expires_with_session() {
+        let app = test_router_with_config(|config| {
+            let TftpConfig::Builtin(tftp) = &mut config.tftp else {
+                panic!("expected builtin TFTP test configuration");
+            };
+            tftp.enabled = false;
+        })
+        .await;
+        let mut board = sample_board("shared-http");
+        let BootConfig::Uboot(profile) = &mut board.boot else {
+            panic!("expected U-Boot board");
+        };
+        profile.use_tftp = false;
+        assert_eq!(create_board(&app, board).await, StatusCode::CREATED);
+        let session_id = create_session(&app, "rk3568").await;
+
+        let profile_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/sessions/{session_id}/boot-profile"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(profile_response.status(), StatusCode::OK);
+        let profile_body = to_bytes(profile_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let profile: BootProfileResponse = serde_json::from_slice(&profile_body).unwrap();
+        assert_eq!(profile.server_ip.as_deref(), Some("127.0.0.1"));
+        assert_eq!(
+            profile.http_base_url.unwrap().as_str(),
+            "http://127.0.0.1:0/"
+        );
+
+        let relative_path = "tools/network/probe script.sh";
+        let upload = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/sessions/{session_id}/files"))
+                    .header("X-File-Path", relative_path)
+                    .body(Body::from("0123456789"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(upload.status(), StatusCode::CREATED);
+        let upload_body = to_bytes(upload.into_body(), usize::MAX).await.unwrap();
+        let uploaded: SharedSessionFileResponse = serde_json::from_slice(&upload_body).unwrap();
+        assert_eq!(uploaded.filename, "probe script.sh");
+        assert_eq!(
+            uploaded.relative_path,
+            format!("ostool/sessions/{session_id}/{relative_path}")
+        );
+        assert_eq!(uploaded.tftp_url, None);
+        let http_url = uploaded.http_url.unwrap();
+        assert_eq!(
+            http_url.as_str(),
+            format!(
+                "http://127.0.0.1:0/share/sessions/{session_id}/tools/network/probe%20script.sh"
+            )
+        );
+
+        let download_path = format!("/share/sessions/{session_id}/tools/network/probe%20script.sh");
+        let download = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(&download_path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(download.status(), StatusCode::OK);
+        let body = to_bytes(download.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), b"0123456789");
+
+        let range = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(&download_path)
+                    .header(header::RANGE, "bytes=2-5")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(range.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(range.headers()[header::CONTENT_RANGE], "bytes 2-5/10");
+        let body = to_bytes(range.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), b"2345");
+
+        let escape = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/sessions/{session_id}/files"))
+                    .header("X-File-Path", "../escape.sh")
+                    .body(Body::from("escape"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(escape.status(), StatusCode::BAD_REQUEST);
+
+        let release = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/sessions/{session_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(release.status(), StatusCode::ACCEPTED);
+
+        let expired = app
+            .oneshot(
+                Request::builder()
+                    .uri(download_path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(expired.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/ostool/Cargo.toml
+++ b/ostool/Cargo.toml
@@ -51,6 +51,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 toml = { workspace = true }
 uboot-shell = { version = "0.2", path = "../uboot-shell" }
+url = { workspace = true }
 
 lzma-rs = "0.3"
 regex = "1"

--- a/ostool/src/board/client.rs
+++ b/ostool/src/board/client.rs
@@ -3,9 +3,10 @@ use std::fmt;
 use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use httpboot_protocol::KernelPublishResponse;
-use reqwest::{Method, StatusCode, Url};
+use reqwest::{Method, StatusCode};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
+use url::Url;
 
 use crate::{
     auth::token_manager::TokenManager,
@@ -137,6 +138,7 @@ pub struct BootProfileResponse {
     pub server_ip: Option<String>,
     pub netmask: Option<String>,
     pub interface: Option<String>,
+    pub http_base_url: Option<Url>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -149,19 +151,23 @@ pub struct SerialStatusResponse {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct FileResponse {
+pub struct SharedSessionFileResponse {
     pub filename: String,
     pub relative_path: String,
-    pub tftp_url: Option<String>,
+    pub tftp_url: Option<Url>,
+    pub http_url: Option<Url>,
     pub size: u64,
     pub uploaded_at: DateTime<Utc>,
 }
+
+#[deprecated(note = "use SharedSessionFileResponse")]
+pub type FileResponse = SharedSessionFileResponse;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct HttpBootFileResponse {
     pub filename: String,
     pub relative_path: String,
-    pub http_url: String,
+    pub http_url: Url,
     pub size: u64,
     pub uploaded_at: DateTime<Utc>,
 }
@@ -173,7 +179,7 @@ pub struct TftpSessionResponse {
     pub server_ip: Option<String>,
     pub netmask: Option<String>,
     pub writable: bool,
-    pub files: Vec<FileResponse>,
+    pub files: Vec<SharedSessionFileResponse>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -181,7 +187,7 @@ pub struct SessionDtbResponse {
     pub dtb_name: Option<String>,
     pub relative_path: Option<String>,
     pub session_file_path: Option<String>,
-    pub tftp_url: Option<String>,
+    pub tftp_url: Option<Url>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -270,7 +276,7 @@ impl BoardServerClient {
         let response = self
             .request(
                 Method::POST,
-                self.endpoint(&format!("/api/v1/sessions/{session_id}/heartbeat")),
+                self.endpoint_segments(&["api", "v1", "sessions", session_id, "heartbeat"]),
             )
             .await?
             .send()
@@ -283,7 +289,7 @@ impl BoardServerClient {
         let response = self
             .request(
                 Method::DELETE,
-                self.endpoint(&format!("/api/v1/sessions/{session_id}")),
+                self.endpoint_segments(&["api", "v1", "sessions", session_id]),
             )
             .await?
             .send()
@@ -302,7 +308,7 @@ impl BoardServerClient {
         let response = self
             .request(
                 Method::GET,
-                self.endpoint(&format!("/api/v1/sessions/{session_id}/boot-profile")),
+                self.endpoint_segments(&["api", "v1", "sessions", session_id, "boot-profile"]),
             )
             .await?
             .send()
@@ -406,11 +412,11 @@ impl BoardServerClient {
         session_id: &str,
         relative_path: &str,
         bytes: Vec<u8>,
-    ) -> Result<FileResponse, BoardServerClientError> {
+    ) -> Result<SharedSessionFileResponse, BoardServerClientError> {
         let response = self
             .request(
                 Method::PUT,
-                self.endpoint(&format!("/api/v1/sessions/{session_id}/files")),
+                self.endpoint_segments(&["api", "v1", "sessions", session_id, "files"]),
             )
             .await?
             .header("X-File-Path", relative_path)
@@ -493,6 +499,19 @@ impl BoardServerClient {
         self.base_url
             .join(path.trim_start_matches('/'))
             .expect("static API path should be valid")
+    }
+
+    fn endpoint_segments(&self, segments: &[&str]) -> Url {
+        let mut url = self.base_url.clone();
+        let mut path = url
+            .path_segments_mut()
+            .expect("HTTP board server URL must support path segments");
+        path.pop_if_empty();
+        for segment in segments {
+            path.push(segment);
+        }
+        drop(path);
+        url
     }
 
     pub async fn websocket_authorization(&self) -> anyhow::Result<Option<String>> {
@@ -613,10 +632,24 @@ impl fmt::Display for BoardTypeSummary {
 
 #[cfg(test)]
 mod tests {
+    use chrono::{DateTime, Utc};
     use reqwest::StatusCode;
+    use serde::Serialize;
+    use url::Url;
 
     use super::{BoardServerClient, BootConfig, parse_error_body};
     use crate::board::global_config::{AuthMode, BoardEndpoint};
+
+    #[derive(Serialize)]
+    struct FutureSharedSessionFileResponse {
+        filename: String,
+        relative_path: String,
+        tftp_url: Option<Url>,
+        http_url: Option<Url>,
+        size: u64,
+        uploaded_at: DateTime<Utc>,
+        checksum: String,
+    }
 
     #[test]
     fn resolve_relative_ws_url_uses_server_defaults() {
@@ -628,6 +661,30 @@ mod tests {
             url.as_str(),
             "ws://127.0.0.1:8080/api/v1/sessions/demo/serial/ws"
         );
+    }
+
+    #[test]
+    fn shared_session_file_response_round_trips_urls_and_ignores_future_fields() {
+        let fixture = FutureSharedSessionFileResponse {
+            filename: "probe script.sh".to_string(),
+            relative_path: "ostool/sessions/demo/tools/probe script.sh".to_string(),
+            tftp_url: None,
+            http_url: Some(
+                Url::parse("http://192.168.1.2:2999/share/sessions/demo/tools/probe%20script.sh")
+                    .unwrap(),
+            ),
+            size: 42,
+            uploaded_at: "2026-07-27T00:00:00Z".parse().unwrap(),
+            checksum: "future-field".to_string(),
+        };
+
+        let encoded = serde_json::to_vec(&fixture).unwrap();
+        let decoded: super::SharedSessionFileResponse = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(decoded.filename, fixture.filename);
+        assert_eq!(decoded.relative_path, fixture.relative_path);
+        assert_eq!(decoded.http_url, fixture.http_url);
+        assert_eq!(decoded.size, fixture.size);
     }
 
     #[test]

--- a/ostool/src/board/config.rs
+++ b/ostool/src/board/config.rs
@@ -14,6 +14,12 @@ use crate::{
 #[serde(deny_unknown_fields)]
 pub struct BoardRunConfig {
     pub board_type: String,
+    /// Files shared with the board for the duration of one session.
+    ///
+    /// Paths are relative to the board configuration file and keep the same
+    /// relative path on the session HTTP endpoint.
+    #[serde(default)]
+    pub session_files: Vec<PathBuf>,
     pub dtb_file: Option<String>,
     pub kernel_load_addr: Option<String>,
     pub fit_load_addr: Option<String>,
@@ -231,6 +237,12 @@ mod tests {
         invocation::{Invocation, InvocationOptions},
     };
     use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    #[derive(serde::Serialize)]
+    struct LegacyBoardRunConfigFixture {
+        board_type: String,
+    }
 
     fn make_invocation(dir: &std::path::Path) -> Invocation {
         Invocation::new(InvocationOptions::new(
@@ -286,6 +298,35 @@ port = 9000
                 .as_str(),
             "http://127.0.0.1:9000/"
         );
+    }
+
+    #[test]
+    fn board_run_config_session_files_toml_round_trip() {
+        let config = BoardRunConfig {
+            board_type: "orangepi-5-plus".to_string(),
+            session_files: vec![
+                PathBuf::from("iperf-smoke.sh"),
+                PathBuf::from("tools/network/probe.sh"),
+            ],
+            ..Default::default()
+        };
+
+        let encoded = toml::to_string(&config).unwrap();
+        let decoded: BoardRunConfig = toml::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, config);
+    }
+
+    #[test]
+    fn legacy_board_run_config_defaults_to_no_session_files() {
+        let fixture = LegacyBoardRunConfigFixture {
+            board_type: "orangepi-5-plus".to_string(),
+        };
+        let encoded = toml::to_string(&fixture).unwrap();
+
+        let decoded: BoardRunConfig = toml::from_str(&encoded).unwrap();
+
+        assert!(decoded.session_files.is_empty());
     }
 
     #[test]

--- a/ostool/src/board/mod.rs
+++ b/ostool/src/board/mod.rs
@@ -2,11 +2,15 @@ pub mod client;
 pub mod config;
 pub mod config_tui;
 pub mod global_config;
+pub mod request;
 pub mod serial_stream;
 pub mod session;
+mod shared_files;
 pub mod terminal;
 
-use std::path::Path;
+pub use request::BoardRunRequest;
+
+use std::{collections::BTreeMap, path::Path};
 
 use anyhow::Context as _;
 
@@ -16,6 +20,7 @@ use crate::board::{
     config_tui::run_board_config_tui,
     global_config::{BoardEndpoint, LoadedBoardGlobalConfig},
     session::BoardSession,
+    shared_files::expand_board_session_variables,
 };
 use crate::{
     build::config::{BuildConfig, BuildSystem, Cargo},
@@ -320,9 +325,25 @@ pub async fn run_prepared_board(
     board_config: &BoardRunConfig,
     options: RunBoardOptions,
 ) -> anyhow::Result<()> {
+    if !board_config.session_files.is_empty() {
+        anyhow::bail!(
+            "board config contains `session_files`; use BoardRunRequest::with_session_files to provide the configuration directory"
+        );
+    }
+    run_prepared_board_with_request(
+        invocation,
+        BoardRunRequest::new(board_config.clone(), options),
+    )
+    .await
+}
+
+pub async fn run_prepared_board_with_request(
+    invocation: &mut Invocation,
+    request: BoardRunRequest,
+) -> anyhow::Result<()> {
     let scope = invocation.variable_scope()?;
     let global_config = load_board_global_config_with_notice()?;
-    let mut board_config = board_config.clone();
+    let (mut board_config, options, session_files) = request.into_parts();
     board_config.apply_overrides(
         &scope,
         options.board_type.as_deref(),
@@ -335,23 +356,58 @@ pub async fn run_prepared_board(
         acquire_board_session_endpoint(endpoint, &board_config.board_type).await?;
     print_allocated_board_session(&session, &board_config.board_type);
 
-    let run_result = match session.info().boot_mode.as_str() {
+    let setup_result = async {
+        if !board_session_setup_required(&board_config, !session_files.is_empty()) {
+            return Ok(());
+        }
+        let context = session.context().await?;
+        let mut uploaded_files = BTreeMap::new();
+        for upload in session_files {
+            let relative_path = upload.relative_path().to_string();
+            let bytes = upload.read().await?;
+            let shared_file = session.upload_shared_file(&relative_path, bytes).await?;
+            uploaded_files.insert(relative_path, shared_file.http_url);
+        }
+        expand_board_session_variables(&mut board_config, &context, &uploaded_files)
+    }
+    .await;
+
+    let run_result = match setup_result {
+        Err(error) => Err(error),
+        Ok(()) => run_allocated_board(invocation, &board_config, client, &session).await,
+    };
+
+    finalize_session(session, run_result).await
+}
+
+fn board_session_setup_required(board_config: &BoardRunConfig, has_session_files: bool) -> bool {
+    has_session_files
+        || board_config
+            .shell_init_cmd
+            .as_deref()
+            .is_some_and(|command| {
+                command.contains("${boardServer") || command.contains("${sessionFile")
+            })
+}
+
+async fn run_allocated_board(
+    invocation: &mut Invocation,
+    board_config: &BoardRunConfig,
+    client: BoardServerClient,
+    session: &BoardSession,
+) -> anyhow::Result<()> {
+    match session.info().boot_mode.as_str() {
         "uboot" => {
             invocation.ensure_runtime_bin()?;
             let input = crate::run::uboot::uboot_run_input(invocation)?;
-            crate::run::uboot::run_uboot_remote(
-                input,
-                &board_config,
-                client,
-                session.info().clone(),
-            )
-            .await
+            crate::run::uboot::run_uboot_remote(input, board_config, client, session.info().clone())
+                .await
         }
         "httpboot" | "uefi_http" => {
             let input = crate::run::uboot::uboot_run_input(invocation)?;
             crate::run::httpboot_board::run_httpboot_remote(
                 input,
-                &board_config,
+                board_config,
                 client,
                 session.info().clone(),
             )
@@ -360,19 +416,41 @@ pub async fn run_prepared_board(
         other => Err(anyhow!(
             "unsupported board boot mode `{other}`; supported modes are `uboot` and `httpboot`"
         )),
-    };
-
-    finalize_session(session, run_result).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{RunBoardOptions, render_board_table};
+    use super::{RunBoardOptions, board_session_setup_required, render_board_table};
     use crate::board::client::BoardTypeSummary;
+    use crate::board::config::BoardRunConfig;
 
     #[test]
     fn run_board_args_default_to_no_overrides() {
         assert_eq!(RunBoardOptions::default().board_type, None);
+    }
+
+    #[test]
+    fn legacy_board_runs_do_not_require_session_network_context() {
+        assert!(!board_session_setup_required(
+            &BoardRunConfig::default(),
+            false
+        ));
+    }
+
+    #[test]
+    fn shared_files_and_reserved_variables_require_session_setup() {
+        assert!(board_session_setup_required(
+            &BoardRunConfig::default(),
+            true
+        ));
+        assert!(board_session_setup_required(
+            &BoardRunConfig {
+                shell_init_cmd: Some("echo ${boardServerIp}".to_string()),
+                ..Default::default()
+            },
+            false
+        ));
     }
 
     #[test]

--- a/ostool/src/board/request.rs
+++ b/ostool/src/board/request.rs
@@ -1,0 +1,37 @@
+use std::path::{Path, PathBuf};
+
+use super::{
+    RunBoardOptions,
+    config::BoardRunConfig,
+    shared_files::{SessionFileUpload, collect_session_files},
+};
+
+#[derive(Clone, Debug)]
+pub struct BoardRunRequest {
+    board_config: BoardRunConfig,
+    options: RunBoardOptions,
+    session_files: Vec<SessionFileUpload>,
+}
+
+impl BoardRunRequest {
+    pub fn new(board_config: BoardRunConfig, options: RunBoardOptions) -> Self {
+        Self {
+            board_config,
+            options,
+            session_files: Vec::new(),
+        }
+    }
+
+    pub fn with_session_files(
+        mut self,
+        root: &Path,
+        relative_paths: &[PathBuf],
+    ) -> anyhow::Result<Self> {
+        self.session_files = collect_session_files(root, relative_paths)?;
+        Ok(self)
+    }
+
+    pub(crate) fn into_parts(self) -> (BoardRunConfig, RunBoardOptions, Vec<SessionFileUpload>) {
+        (self.board_config, self.options, self.session_files)
+    }
+}

--- a/ostool/src/board/session.rs
+++ b/ostool/src/board/session.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{future::Future, net::IpAddr, sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use chrono::{DateTime, Utc};
@@ -6,8 +6,27 @@ use tokio::{
     sync::{RwLock, watch},
     task::JoinHandle,
 };
+use url::Url;
 
-use crate::board::client::{BoardServerClient, BoardServerClientError, SessionCreatedResponse};
+use crate::board::client::{
+    BoardServerClient, BoardServerClientError, SessionCreatedResponse, SharedSessionFileResponse,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoardSessionContext {
+    pub session_id: String,
+    pub server_ip: IpAddr,
+    pub http_base_url: Url,
+}
+
+#[derive(Clone, Debug)]
+pub struct SharedSessionFile {
+    pub filename: String,
+    pub relative_path: String,
+    pub http_url: Url,
+    pub size: u64,
+    pub uploaded_at: DateTime<Utc>,
+}
 
 #[derive(Debug)]
 pub struct BoardSession {
@@ -53,6 +72,46 @@ impl BoardSession {
         *self.lease_expires_at.read().await
     }
 
+    pub async fn context(&self) -> anyhow::Result<BoardSessionContext> {
+        let profile = self
+            .client
+            .get_boot_profile(&self.info.session_id)
+            .await
+            .context("failed to get board session network context")?;
+        let server_ip = profile
+            .server_ip
+            .as_deref()
+            .ok_or_else(|| anyhow!("board server did not report a board-reachable IP address"))?
+            .parse::<IpAddr>()
+            .with_context(|| {
+                format!(
+                    "board server returned invalid board-reachable IP address `{}`",
+                    profile.server_ip.as_deref().unwrap_or_default()
+                )
+            })?;
+        let http_base_url = profile.http_base_url.ok_or_else(|| {
+            anyhow!("board server did not report a board-reachable shared HTTP URL")
+        })?;
+        Ok(BoardSessionContext {
+            session_id: self.info.session_id.clone(),
+            server_ip,
+            http_base_url,
+        })
+    }
+
+    pub async fn upload_shared_file(
+        &self,
+        relative_path: &str,
+        bytes: Vec<u8>,
+    ) -> anyhow::Result<SharedSessionFile> {
+        let response = self
+            .client
+            .upload_session_file(&self.info.session_id, relative_path, bytes)
+            .await
+            .with_context(|| format!("failed to upload shared session file `{relative_path}`"))?;
+        shared_session_file_from_response(relative_path, response)
+    }
+
     pub async fn release(mut self) -> anyhow::Result<()> {
         self.stop_heartbeat();
         if let Some(task) = self.heartbeat_task.take() {
@@ -74,6 +133,24 @@ impl BoardSession {
     fn stop_heartbeat(&self) {
         let _ = self.heartbeat_stop.send(true);
     }
+}
+
+fn shared_session_file_from_response(
+    requested_relative_path: &str,
+    response: SharedSessionFileResponse,
+) -> anyhow::Result<SharedSessionFile> {
+    let http_url = response.http_url.ok_or_else(|| {
+        anyhow!(
+            "board server did not return an HTTP URL for shared session file `{requested_relative_path}`"
+        )
+    })?;
+    Ok(SharedSessionFile {
+        filename: response.filename,
+        relative_path: requested_relative_path.to_string(),
+        http_url,
+        size: response.size,
+        uploaded_at: response.uploaded_at,
+    })
 }
 
 impl Drop for BoardSession {
@@ -153,8 +230,10 @@ mod tests {
     use chrono::Utc;
     use reqwest::StatusCode;
 
-    use super::acquire_session_with;
-    use crate::board::client::{BoardServerClientError, SessionCreatedResponse};
+    use super::{acquire_session_with, shared_session_file_from_response};
+    use crate::board::client::{
+        BoardServerClientError, SessionCreatedResponse, SharedSessionFileResponse,
+    };
 
     fn created_session(id: &str) -> SessionCreatedResponse {
         SessionCreatedResponse {
@@ -173,6 +252,27 @@ mod tests {
             code: Some("conflict".to_string()),
             message: format!("no available board for type `{board_type}`"),
         }
+    }
+
+    #[test]
+    fn shared_file_keeps_the_requested_relative_path() {
+        let uploaded_at = Utc::now();
+        let response = SharedSessionFileResponse {
+            filename: "probe.sh".to_string(),
+            relative_path: "ostool/sessions/demo/tools/probe.sh".to_string(),
+            tftp_url: None,
+            http_url: Some(
+                "http://192.168.1.2:2999/share/sessions/demo/tools/probe.sh"
+                    .parse()
+                    .unwrap(),
+            ),
+            size: 5,
+            uploaded_at,
+        };
+
+        let shared = shared_session_file_from_response("tools/probe.sh", response).unwrap();
+
+        assert_eq!(shared.relative_path, "tools/probe.sh");
     }
 
     #[tokio::test]

--- a/ostool/src/board/shared_files.rs
+++ b/ostool/src/board/shared_files.rs
@@ -1,0 +1,241 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{Context as _, bail};
+use url::Url;
+
+use super::{config::BoardRunConfig, session::BoardSessionContext};
+use crate::utils::replace_placeholders;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionFileUpload {
+    source_path: PathBuf,
+    relative_path: String,
+}
+
+impl SessionFileUpload {
+    pub fn from_root(root: &Path, relative_path: &Path) -> anyhow::Result<Self> {
+        let relative_path = normalize_relative_path(relative_path)?;
+        let canonical_root = root
+            .canonicalize()
+            .with_context(|| format!("failed to resolve shared file root {}", root.display()))?;
+        let source_path = canonical_root.join(&relative_path);
+        let canonical_source = source_path.canonicalize().with_context(|| {
+            format!(
+                "failed to resolve shared session file {}",
+                source_path.display()
+            )
+        })?;
+        if !canonical_source.starts_with(&canonical_root) {
+            bail!(
+                "shared session file `{relative_path}` resolves outside {}",
+                canonical_root.display()
+            );
+        }
+        if !canonical_source.is_file() {
+            bail!(
+                "shared session file `{relative_path}` is not a regular file under {}",
+                canonical_root.display()
+            );
+        }
+        Ok(Self {
+            source_path: canonical_source,
+            relative_path,
+        })
+    }
+
+    pub fn relative_path(&self) -> &str {
+        &self.relative_path
+    }
+
+    pub(crate) async fn read(&self) -> anyhow::Result<Vec<u8>> {
+        tokio::fs::read(&self.source_path).await.with_context(|| {
+            format!(
+                "failed to read shared session file {}",
+                self.source_path.display()
+            )
+        })
+    }
+}
+
+pub(crate) fn collect_session_files(
+    root: &Path,
+    relative_paths: &[PathBuf],
+) -> anyhow::Result<Vec<SessionFileUpload>> {
+    let mut seen = BTreeSet::new();
+    let mut uploads = Vec::with_capacity(relative_paths.len());
+    for relative_path in relative_paths {
+        let upload = SessionFileUpload::from_root(root, relative_path)?;
+        if !seen.insert(upload.relative_path.clone()) {
+            bail!(
+                "duplicate shared session file path `{}`",
+                upload.relative_path
+            );
+        }
+        uploads.push(upload);
+    }
+    Ok(uploads)
+}
+
+pub(crate) fn expand_board_session_variables(
+    board_config: &mut BoardRunConfig,
+    context: &BoardSessionContext,
+    uploaded_files: &BTreeMap<String, Url>,
+) -> anyhow::Result<()> {
+    let Some(shell_init_cmd) = board_config.shell_init_cmd.as_deref() else {
+        return Ok(());
+    };
+    let expanded = replace_placeholders(shell_init_cmd, |placeholder| match placeholder {
+        "boardServerIp" => Ok(Some(context.server_ip.to_string())),
+        "boardServerHttpBaseUrl" => Ok(Some(context.http_base_url.to_string())),
+        "sessionFile" => bail!("session file placeholder must include a relative path"),
+        value if value.starts_with("sessionFile:") => {
+            let relative_path = value.trim_start_matches("sessionFile:");
+            let relative_path = normalize_relative_path(Path::new(relative_path))?;
+            let url = uploaded_files.get(&relative_path).ok_or_else(|| {
+                    anyhow!(
+                        "shell_init_cmd references shared session file `{relative_path}` that was not uploaded"
+                    )
+                })?;
+            Ok(Some(url.to_string()))
+        }
+        value if value.starts_with("boardServer") || value.starts_with("sessionFile") => {
+            bail!("unknown board session placeholder `${{{value}}}`")
+        }
+        _ => Ok(None),
+    })?;
+    board_config.shell_init_cmd = Some(expanded);
+    Ok(())
+}
+
+fn normalize_relative_path(path: &Path) -> anyhow::Result<String> {
+    if path.as_os_str().is_empty() {
+        bail!("shared session file path must not be empty");
+    }
+    let mut segments = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => {
+                let segment = segment
+                    .to_str()
+                    .ok_or_else(|| anyhow!("shared session file path must contain valid UTF-8"))?;
+                if segment.trim().is_empty() {
+                    bail!("shared session file path contains an empty segment");
+                }
+                segments.push(segment.to_string());
+            }
+            Component::CurDir => bail!("shared session file path must not contain `.` segments"),
+            Component::ParentDir => {
+                bail!("shared session file path must not contain `..` segments")
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                bail!("shared session file path must be relative")
+            }
+        }
+    }
+    if segments.is_empty() {
+        bail!("shared session file path must not be empty");
+    }
+    Ok(segments.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, fs, net::IpAddr, path::PathBuf};
+
+    use tempfile::tempdir;
+    use url::Url;
+
+    use super::{collect_session_files, expand_board_session_variables};
+    use crate::board::{config::BoardRunConfig, session::BoardSessionContext};
+
+    #[test]
+    fn shared_files_keep_their_relative_paths() {
+        let root = tempdir().unwrap();
+        fs::create_dir_all(root.path().join("tools/network")).unwrap();
+        fs::write(root.path().join("tools/network/probe.sh"), b"probe").unwrap();
+
+        let uploads =
+            collect_session_files(root.path(), &[PathBuf::from("tools/network/probe.sh")]).unwrap();
+
+        assert_eq!(uploads[0].relative_path(), "tools/network/probe.sh");
+    }
+
+    #[test]
+    fn shared_files_reject_parent_and_symlink_escape() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        fs::write(outside.path().join("probe.sh"), b"probe").unwrap();
+        assert!(collect_session_files(root.path(), &[PathBuf::from("../probe.sh")]).is_err());
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(
+                outside.path().join("probe.sh"),
+                root.path().join("probe.sh"),
+            )
+            .unwrap();
+            assert!(collect_session_files(root.path(), &[PathBuf::from("probe.sh")]).is_err());
+        }
+    }
+
+    #[test]
+    fn shared_files_reject_duplicate_paths() {
+        let root = tempdir().unwrap();
+        fs::write(root.path().join("probe.sh"), b"probe").unwrap();
+
+        let error = collect_session_files(
+            root.path(),
+            &[PathBuf::from("probe.sh"), PathBuf::from("probe.sh")],
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn session_variables_expand_known_values_and_preserve_shell_variables() {
+        let mut config = BoardRunConfig {
+            shell_init_cmd: Some(
+                "server=${boardServerIp}; file=${sessionFile:tools/probe.sh}; echo ${marker}"
+                    .into(),
+            ),
+            ..Default::default()
+        };
+        let context = BoardSessionContext {
+            session_id: "session-1".into(),
+            server_ip: "192.168.1.2".parse::<IpAddr>().unwrap(),
+            http_base_url: Url::parse("http://192.168.1.2:2999/").unwrap(),
+        };
+        let files = BTreeMap::from([(
+            "tools/probe.sh".into(),
+            Url::parse("http://192.168.1.2:2999/share/sessions/session-1/tools/probe.sh").unwrap(),
+        )]);
+
+        expand_board_session_variables(&mut config, &context, &files).unwrap();
+
+        assert_eq!(
+            config.shell_init_cmd.as_deref(),
+            Some(
+                "server=192.168.1.2; file=http://192.168.1.2:2999/share/sessions/session-1/tools/probe.sh; echo ${marker}"
+            )
+        );
+    }
+
+    #[test]
+    fn session_variables_reject_missing_uploaded_file() {
+        let mut config = BoardRunConfig {
+            shell_init_cmd: Some("${sessionFile:missing.sh}".into()),
+            ..Default::default()
+        };
+        let context = BoardSessionContext {
+            session_id: "session-1".into(),
+            server_ip: "192.168.1.2".parse().unwrap(),
+            http_base_url: Url::parse("http://192.168.1.2:2999/").unwrap(),
+        };
+
+        assert!(expand_board_session_variables(&mut config, &context, &BTreeMap::new()).is_err());
+    }
+}

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -2280,6 +2280,7 @@ interface = "eth0"
     fn uboot_config_from_board_run_config_keeps_dtb_file() {
         let config = UbootConfig::from_board_run_config(&BoardRunConfig {
             board_type: "rk3568".into(),
+            session_files: Vec::new(),
             dtb_file: Some("/tmp/board.dtb".into()),
             kernel_load_addr: Some("0x80200000".into()),
             fit_load_addr: Some("0x82200000".into()),


### PR DESCRIPTION
## 问题

现有 board session 文件只能通过控制 API 管理，并依赖 TFTP 提供板端访问。测试用例无法在任意 boot mode 下把临时脚本按原相对路径共享给开发板，也无法获得板端网络可访问的服务地址。

## 修改

- 新增 `GET /share/sessions/{session_id}/{relative_path}`，支持完整与单段 Range 下载；session 释放、超时或进入 releasing 后立即返回 404。
- session 文件上传响应新增 typed `http_url`，boot profile 新增板端可达的 `http_base_url`；HTTP/TFTP URL 均通过 `url::Url` 构造与 Serde 编解码。
- HTTP 共享复用现有 session 文件存储、大小限制和清理流程，不依赖 TFTP 是否启用。
- 新增 `BoardSessionContext`、`BoardSession::context()`、`BoardSession::upload_shared_file()` 和 `BoardRunRequest`。
- `session_files` 保留相对于配置目录的原路径，不提供 alias 或上传改名；拒绝绝对路径、`..`、符号链接逃逸、重复路径和缺失文件。
- 运行前展开 `${boardServerIp}`、`${boardServerHttpBaseUrl}` 和 `${sessionFile:<relative-path>}`，普通 shell 变量保持原样；任一准备或运行失败仍进入 session release 流程。
- 将相关协议响应改为具名 Serde 类型，并保留旧 `FileResponse` 类型别名兼容已有调用方。

## 实现逻辑

服务端从已解析的板端网络配置生成共享 HTTP URL，URL 路径段由 `Url` API 编码。共享下载端点只允许访问活动 session，并从同一 session 存储读取文件，因此租约和清理状态是唯一生命周期来源。

客户端先验证本地相对路径边界，再分配 session、获取板端网络上下文、逐文件上传和展开保留变量。没有共享文件或 session 变量的旧调用路径不会请求新字段，可继续连接旧服务端。

## 验证

- `cargo test -p ostool -p ostool-server --no-fail-fast`
- `cargo clippy -p ostool -p ostool-server --all-targets -- -D warnings`
- 覆盖 TFTP 关闭、嵌套和 URL 编码路径、完整/Range 下载、路径逃逸、释放后 404、Serde round-trip、未来字段兼容及旧 board run 兼容路径。
