### PR TITLE
feat(board): run shared session programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,11 +317,30 @@ ostool board config
 `server` 应使用包含 `http://` 或 `https://` 的完整 URL；可选的 `port` 会覆盖 URL 中的端口。为兼容旧的局域网配置，裸 IPv4 或 IPv6 地址会自动补为 `http://`。基线版本写出的 `server_ip` / `port` 也会在读取时迁移为 `server` / `port`，下一次保存配置时只写新格式；无 scheme 的主机名不支持。项目级 `.board.toml` 中的 `server` / `port` 仍可用于 `ostool board run`，其优先级低于命令行参数，高于全局配置。
 
 `.board.toml` 可以用 `session_files` 声明相对于配置文件目录的共享文件。调用方通过
-`BoardRunRequest::with_session_files` 提供该目录，ostool 会在 board session
+`BoardRunRequest::with_session_root` 提供该目录，ostool 会在 board session
 建立后按原相对路径上传，并在 `shell_init_cmd` 中展开
 `${boardServerIp}`、`${boardServerHttpBaseUrl}` 和
 `${sessionFile:<relative-path>}`。绝对路径、`..`、符号链接逃逸、重复路径及缺失
 文件都会在运行前被拒绝；接口不提供 alias 或上传改名。
+
+只需运行一个共享程序时，可改用声明式配置：
+
+```toml
+board_type = "AKA-00-SG2002"
+shell_prefix = "root@starry:"
+success_regex = ["(?m)^PROGRAM_OK\\s*$"]
+
+[session_program]
+path = "bin/probe"
+args = ["--server", "${boardServerIp}"]
+```
+
+`session_program.path` 会自动加入共享文件，无需同时写入 `session_files`。检测到 shell
+prompt 后，ostool 在 `/tmp/ostool-session/<session_id>/` 下按原相对路径下载所有
+session 文件，为程序添加执行权限，并以经过 POSIX shell 引号保护的 argv 运行程序。
+下载会在 60 秒内依次尝试 curl 和 wget；下载、赋权或程序退出失败都会触发 board
+测试失败并进入正常的 session release 流程。`session_program` 与
+`shell_init_cmd` 互斥。
 
 ### 公网开发板认证
 

--- a/ostool/src/board/config.rs
+++ b/ostool/src/board/config.rs
@@ -10,6 +10,17 @@ use crate::{
     run::shell_init::normalize_shell_init_config,
 };
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BoardSessionProgram {
+    /// Program path relative to the board configuration's session root.
+    pub path: PathBuf,
+    /// Literal argv entries. Project and board-session placeholders are expanded
+    /// before each entry is POSIX-shell quoted.
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BoardRunConfig {
@@ -20,6 +31,9 @@ pub struct BoardRunConfig {
     /// relative path on the session HTTP endpoint.
     #[serde(default)]
     pub session_files: Vec<PathBuf>,
+    /// Program uploaded, downloaded, and executed for this board session.
+    #[serde(default)]
+    pub session_program: Option<BoardSessionProgram>,
     pub dtb_file: Option<String>,
     pub kernel_load_addr: Option<String>,
     pub fit_load_addr: Option<String>,
@@ -168,6 +182,13 @@ impl BoardRunConfig {
             .as_deref()
             .map(|value| variables::expand_variables(value, scope))
             .transpose()?;
+        if let Some(program) = self.session_program.as_mut() {
+            program.args = program
+                .args
+                .iter()
+                .map(|value| variables::expand_variables(value, scope))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+        }
         self.server = self
             .server
             .as_deref()
@@ -212,7 +233,34 @@ impl BoardRunConfig {
             &mut self.shell_prefix,
             &mut self.shell_init_cmd,
             config_name,
-        )
+        )?;
+        if let Some(program) = self.session_program.as_ref() {
+            if self.shell_init_cmd.is_some() {
+                anyhow::bail!(
+                    "`session_program` and `shell_init_cmd` are mutually exclusive in {config_name}"
+                );
+            }
+            if self.shell_prefix.is_none() {
+                anyhow::bail!("`session_program` requires `shell_prefix` in {config_name}");
+            }
+            if program.path.as_os_str().is_empty() {
+                anyhow::bail!("`session_program.path` must not be empty in {config_name}");
+            }
+            if program.path.to_string_lossy().contains("${") {
+                anyhow::bail!("`session_program.path` must not contain variables in {config_name}");
+            }
+            if let Some(argument) = program
+                .args
+                .iter()
+                .find(|argument| argument.contains(['\0', '\r', '\n']))
+            {
+                anyhow::bail!(
+                    "`session_program.args` must not contain NUL or newline characters in \
+                     {config_name}: {argument:?}"
+                );
+            }
+        }
+        Ok(())
     }
 }
 
@@ -229,7 +277,7 @@ fn normalize_optional_string(value: &mut Option<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::BoardRunConfig;
+    use super::{BoardRunConfig, BoardSessionProgram};
     use crate::{
         board::global_config::BoardGlobalConfig,
         board::{ensure_run_config_in_dir, read_run_config_from_path},
@@ -318,6 +366,28 @@ port = 9000
     }
 
     #[test]
+    fn board_run_config_session_program_toml_round_trip() {
+        let config = BoardRunConfig {
+            board_type: "aka-00-sg2002".to_string(),
+            shell_prefix: Some("root@starry:".to_string()),
+            session_program: Some(BoardSessionProgram {
+                path: PathBuf::from("bin/sg2002-libuvc-init"),
+                args: vec![
+                    "--server".to_string(),
+                    "${boardServerIp}".to_string(),
+                    "argument with spaces".to_string(),
+                ],
+            }),
+            ..Default::default()
+        };
+
+        let encoded = toml::to_string(&config).unwrap();
+        let decoded: BoardRunConfig = toml::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, config);
+    }
+
+    #[test]
     fn legacy_board_run_config_defaults_to_no_session_files() {
         let fixture = LegacyBoardRunConfigFixture {
             board_type: "orangepi-5-plus".to_string(),
@@ -327,6 +397,44 @@ port = 9000
         let decoded: BoardRunConfig = toml::from_str(&encoded).unwrap();
 
         assert!(decoded.session_files.is_empty());
+        assert!(decoded.session_program.is_none());
+    }
+
+    #[test]
+    fn session_program_rejects_shell_init_command_and_missing_prefix() {
+        let mut conflicting = BoardRunConfig {
+            board_type: "aka-00-sg2002".to_string(),
+            shell_prefix: Some("root@starry:".to_string()),
+            shell_init_cmd: Some("echo legacy".to_string()),
+            session_program: Some(BoardSessionProgram {
+                path: PathBuf::from("bin/probe"),
+                args: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            conflicting
+                .normalize("test board config")
+                .unwrap_err()
+                .to_string()
+                .contains("mutually exclusive")
+        );
+
+        let mut missing_prefix = BoardRunConfig {
+            board_type: "aka-00-sg2002".to_string(),
+            session_program: Some(BoardSessionProgram {
+                path: PathBuf::from("bin/probe"),
+                args: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            missing_prefix
+                .normalize("test board config")
+                .unwrap_err()
+                .to_string()
+                .contains("shell_prefix")
+        );
     }
 
     #[test]

--- a/ostool/src/board/mod.rs
+++ b/ostool/src/board/mod.rs
@@ -325,9 +325,9 @@ pub async fn run_prepared_board(
     board_config: &BoardRunConfig,
     options: RunBoardOptions,
 ) -> anyhow::Result<()> {
-    if !board_config.session_files.is_empty() {
+    if !board_config.session_files.is_empty() || board_config.session_program.is_some() {
         anyhow::bail!(
-            "board config contains `session_files`; use BoardRunRequest::with_session_files to provide the configuration directory"
+            "board config contains session assets; use BoardRunRequest::with_session_root to provide the session root"
         );
     }
     run_prepared_board_with_request(
@@ -382,6 +382,7 @@ pub async fn run_prepared_board_with_request(
 
 fn board_session_setup_required(board_config: &BoardRunConfig, has_session_files: bool) -> bool {
     has_session_files
+        || board_config.session_program.is_some()
         || board_config
             .shell_init_cmd
             .as_deref()

--- a/ostool/src/board/request.rs
+++ b/ostool/src/board/request.rs
@@ -27,11 +27,84 @@ impl BoardRunRequest {
         root: &Path,
         relative_paths: &[PathBuf],
     ) -> anyhow::Result<Self> {
-        self.session_files = collect_session_files(root, relative_paths)?;
+        let mut declared_paths = relative_paths.to_vec();
+        if let Some(program) = self.board_config.session_program.as_ref() {
+            declared_paths.push(program.path.clone());
+        }
+        self.session_files = collect_session_files(root, &declared_paths)?;
+        Ok(self)
+    }
+
+    /// Resolves every file declared by the board configuration under `root`.
+    ///
+    /// This includes both `session_files` and `session_program.path`.
+    pub fn with_session_root(mut self, root: &Path) -> anyhow::Result<Self> {
+        let declared_files = self.board_config.session_files.clone();
+        self = self.with_session_files(root, &declared_files)?;
         Ok(self)
     }
 
     pub(crate) fn into_parts(self) -> (BoardRunConfig, RunBoardOptions, Vec<SessionFileUpload>) {
         (self.board_config, self.options, self.session_files)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::board::config::BoardSessionProgram;
+
+    #[test]
+    fn session_root_collects_declared_files_and_program() {
+        let root = tempdir().unwrap();
+        fs::create_dir_all(root.path().join("bin")).unwrap();
+        fs::write(root.path().join("config.toml"), b"config").unwrap();
+        fs::write(root.path().join("bin/probe"), b"probe").unwrap();
+        let config = BoardRunConfig {
+            board_type: "test-board".into(),
+            session_files: vec![PathBuf::from("config.toml")],
+            session_program: Some(BoardSessionProgram {
+                path: PathBuf::from("bin/probe"),
+                args: Vec::new(),
+            }),
+            ..Default::default()
+        };
+
+        let request = BoardRunRequest::new(config, RunBoardOptions::default())
+            .with_session_root(root.path())
+            .unwrap();
+        let (_, _, uploads) = request.into_parts();
+        let paths = uploads
+            .iter()
+            .map(SessionFileUpload::relative_path)
+            .collect::<Vec<_>>();
+
+        assert_eq!(paths, ["config.toml", "bin/probe"]);
+    }
+
+    #[test]
+    fn session_root_rejects_duplicate_program_path() {
+        let root = tempdir().unwrap();
+        fs::create_dir_all(root.path().join("bin")).unwrap();
+        fs::write(root.path().join("bin/probe"), b"probe").unwrap();
+        let config = BoardRunConfig {
+            board_type: "test-board".into(),
+            session_files: vec![PathBuf::from("bin/probe")],
+            session_program: Some(BoardSessionProgram {
+                path: PathBuf::from("bin/probe"),
+                args: Vec::new(),
+            }),
+            ..Default::default()
+        };
+
+        let error = BoardRunRequest::new(config, RunBoardOptions::default())
+            .with_session_root(root.path())
+            .unwrap_err();
+
+        assert!(error.to_string().contains("duplicate"));
     }
 }

--- a/ostool/src/board/shared_files.rs
+++ b/ostool/src/board/shared_files.rs
@@ -9,6 +9,9 @@ use url::Url;
 use super::{config::BoardRunConfig, session::BoardSessionContext};
 use crate::utils::replace_placeholders;
 
+pub(crate) const SESSION_PROGRAM_FAILURE_MARKER: &str = "OSTOOL_SESSION_PROGRAM_FAILED";
+const SESSION_PROGRAM_DOWNLOAD_ATTEMPTS: u32 = 60;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SessionFileUpload {
     source_path: PathBuf,
@@ -84,10 +87,27 @@ pub(crate) fn expand_board_session_variables(
     context: &BoardSessionContext,
     uploaded_files: &BTreeMap<String, Url>,
 ) -> anyhow::Result<()> {
-    let Some(shell_init_cmd) = board_config.shell_init_cmd.as_deref() else {
-        return Ok(());
-    };
-    let expanded = replace_placeholders(shell_init_cmd, |placeholder| match placeholder {
+    if let Some(shell_init_cmd) = board_config.shell_init_cmd.as_deref() {
+        board_config.shell_init_cmd = Some(expand_session_placeholders(
+            shell_init_cmd,
+            "shell_init_cmd",
+            context,
+            uploaded_files,
+        )?);
+    }
+    if board_config.session_program.is_some() {
+        prepare_session_program(board_config, context, uploaded_files)?;
+    }
+    Ok(())
+}
+
+fn expand_session_placeholders(
+    value: &str,
+    field_name: &str,
+    context: &BoardSessionContext,
+    uploaded_files: &BTreeMap<String, Url>,
+) -> anyhow::Result<String> {
+    replace_placeholders(value, |placeholder| match placeholder {
         "boardServerIp" => Ok(Some(context.server_ip.to_string())),
         "boardServerHttpBaseUrl" => Ok(Some(context.http_base_url.to_string())),
         "sessionFile" => bail!("session file placeholder must include a relative path"),
@@ -95,19 +115,99 @@ pub(crate) fn expand_board_session_variables(
             let relative_path = value.trim_start_matches("sessionFile:");
             let relative_path = normalize_relative_path(Path::new(relative_path))?;
             let url = uploaded_files.get(&relative_path).ok_or_else(|| {
-                    anyhow!(
-                        "shell_init_cmd references shared session file `{relative_path}` that was not uploaded"
-                    )
-                })?;
+                anyhow!(
+                    "{field_name} references shared session file `{relative_path}` that was not uploaded"
+                )
+            })?;
             Ok(Some(url.to_string()))
         }
         value if value.starts_with("boardServer") || value.starts_with("sessionFile") => {
             bail!("unknown board session placeholder `${{{value}}}`")
         }
         _ => Ok(None),
-    })?;
-    board_config.shell_init_cmd = Some(expanded);
+    })
+}
+
+fn prepare_session_program(
+    board_config: &mut BoardRunConfig,
+    context: &BoardSessionContext,
+    uploaded_files: &BTreeMap<String, Url>,
+) -> anyhow::Result<()> {
+    let program = board_config
+        .session_program
+        .as_ref()
+        .expect("caller checked session_program")
+        .clone();
+    let program_path = normalize_relative_path(&program.path)?;
+    if !uploaded_files.contains_key(&program_path) {
+        bail!("session program `{program_path}` was not uploaded");
+    }
+
+    let session_root = format!("/tmp/ostool-session/{}", context.session_id);
+    let mut command = String::from(
+        "ostool_marker=OSTOOL_SESSION_PROGRAM; \
+         ostool_fetch() { ostool_url=$1; ostool_dest=$2; ostool_try=0; \
+         while [ \"$ostool_try\" -lt ",
+    );
+    command.push_str(&SESSION_PROGRAM_DOWNLOAD_ATTEMPTS.to_string());
+    command.push_str(
+        " ]; do \
+         if command -v curl >/dev/null 2>&1 && \
+         curl --connect-timeout 2 --max-time 5 -fsSL \"$ostool_url\" -o \"$ostool_dest\"; \
+         then return 0; fi; \
+         if command -v wget >/dev/null 2>&1 && \
+         wget -T 5 -O \"$ostool_dest\" \"$ostool_url\"; then return 0; fi; \
+         ostool_try=$((ostool_try + 1)); sleep 1; done; return 1; }; ",
+    );
+    command.push_str("ostool_root=");
+    command.push_str(&posix_shell_quote(&session_root));
+    command.push_str("; rm -rf \"$ostool_root\" && mkdir -p \"$ostool_root\"");
+
+    for (relative_path, url) in uploaded_files {
+        let parent = relative_path.rsplit_once('/').map(|(parent, _)| parent);
+        command.push_str(" && mkdir -p ");
+        command.push_str(&session_root_path(parent));
+        command.push_str(" && ostool_fetch ");
+        command.push_str(&posix_shell_quote(url.as_str()));
+        command.push(' ');
+        command.push_str(&session_root_path(Some(relative_path)));
+    }
+
+    command.push_str(" && chmod +x ");
+    command.push_str(&session_root_path(Some(&program_path)));
+    command.push_str(" && cd \"$ostool_root\" && ");
+    command.push_str(&posix_shell_quote(&format!("./{program_path}")));
+    for (index, argument) in program.args.iter().enumerate() {
+        let argument = expand_session_placeholders(
+            argument,
+            &format!("session_program.args[{index}]"),
+            context,
+            uploaded_files,
+        )?;
+        command.push(' ');
+        command.push_str(&posix_shell_quote(&argument));
+    }
+    command.push_str(" || echo \"${ostool_marker}_FAILED\"");
+
+    let failure_regex = format!(r"(?m)^{SESSION_PROGRAM_FAILURE_MARKER}\s*$");
+    if !board_config.fail_regex.contains(&failure_regex) {
+        board_config.fail_regex.push(failure_regex);
+    }
+    board_config.shell_init_cmd = Some(command);
     Ok(())
+}
+
+fn posix_shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn session_root_path(relative_path: Option<&str>) -> String {
+    match relative_path {
+        Some(relative_path) => {
+            format!("\"$ostool_root\"/{}", posix_shell_quote(relative_path))
+        }
+        None => "\"$ostool_root\"".to_string(),
+    }
 }
 
 fn normalize_relative_path(path: &Path) -> anyhow::Result<String> {
@@ -143,13 +243,18 @@ fn normalize_relative_path(path: &Path) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, fs, net::IpAddr, path::PathBuf};
+    use std::{collections::BTreeMap, fs, net::IpAddr, path::PathBuf, process::Command};
 
     use tempfile::tempdir;
     use url::Url;
 
-    use super::{collect_session_files, expand_board_session_variables};
-    use crate::board::{config::BoardRunConfig, session::BoardSessionContext};
+    use super::{
+        SESSION_PROGRAM_FAILURE_MARKER, collect_session_files, expand_board_session_variables,
+    };
+    use crate::board::{
+        config::{BoardRunConfig, BoardSessionProgram},
+        session::BoardSessionContext,
+    };
 
     #[test]
     fn shared_files_keep_their_relative_paths() {
@@ -237,5 +342,159 @@ mod tests {
         };
 
         assert!(expand_board_session_variables(&mut config, &context, &BTreeMap::new()).is_err());
+    }
+
+    #[test]
+    fn session_program_builds_download_and_exec_command_with_quoted_args() {
+        let mut config = BoardRunConfig {
+            shell_prefix: Some("root@starry:".into()),
+            session_program: Some(BoardSessionProgram {
+                path: PathBuf::from("bin/probe"),
+                args: vec![
+                    "--server=${boardServerIp}".into(),
+                    "argument with spaces".into(),
+                    "single'quote".into(),
+                ],
+            }),
+            ..Default::default()
+        };
+        let context = BoardSessionContext {
+            session_id: "session-1".into(),
+            server_ip: "192.168.1.2".parse().unwrap(),
+            http_base_url: Url::parse("http://192.168.1.2:2999/").unwrap(),
+        };
+        let files = BTreeMap::from([(
+            "bin/probe".into(),
+            Url::parse("http://192.168.1.2:2999/share/sessions/session-1/bin/probe").unwrap(),
+        )]);
+
+        expand_board_session_variables(&mut config, &context, &files).unwrap();
+
+        let command = config.shell_init_cmd.as_deref().unwrap();
+        assert!(command.contains("/tmp/ostool-session/session-1"));
+        assert!(command.contains("share/sessions/session-1/bin/probe"));
+        assert!(command.contains("'--server=192.168.1.2'"));
+        assert!(command.contains("'argument with spaces'"));
+        assert!(command.contains("'single'\"'\"'quote'"));
+        assert!(command.contains("curl"));
+        assert!(command.contains("wget"));
+        assert!(command.contains("${ostool_marker}_FAILED"));
+        assert!(!command.contains(SESSION_PROGRAM_FAILURE_MARKER));
+        assert!(
+            config
+                .fail_regex
+                .iter()
+                .any(|regex| regex.contains(SESSION_PROGRAM_FAILURE_MARKER))
+        );
+    }
+
+    #[test]
+    fn session_program_rejects_missing_uploaded_program() {
+        let mut config = BoardRunConfig {
+            shell_prefix: Some("root@starry:".into()),
+            session_program: Some(BoardSessionProgram {
+                path: PathBuf::from("bin/missing"),
+                args: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        let context = BoardSessionContext {
+            session_id: "session-1".into(),
+            server_ip: "192.168.1.2".parse().unwrap(),
+            http_base_url: Url::parse("http://192.168.1.2:2999/").unwrap(),
+        };
+
+        let error =
+            expand_board_session_variables(&mut config, &context, &BTreeMap::new()).unwrap_err();
+
+        assert!(error.to_string().contains("bin/missing"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn session_program_command_downloads_executes_and_reports_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tools = tempdir().unwrap();
+        let curl = tools.path().join("curl");
+        fs::write(
+            &curl,
+            r#"#!/bin/sh
+destination=
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        shift
+        destination=$1
+    fi
+    shift
+done
+cat >"$destination" <<'PROGRAM'
+#!/bin/sh
+printf 'PROBE_ARG=%s\n' "$1"
+exit "${OSTOOL_FAKE_PROGRAM_EXIT:-0}"
+PROGRAM
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&curl).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&curl, permissions).unwrap();
+
+        let mut config = BoardRunConfig {
+            shell_prefix: Some("root@starry:".into()),
+            session_program: Some(BoardSessionProgram {
+                path: PathBuf::from("bin/probe"),
+                args: vec!["argument with spaces".into()],
+            }),
+            ..Default::default()
+        };
+        let context = BoardSessionContext {
+            session_id: "session-shell-test".into(),
+            server_ip: "192.168.1.2".parse().unwrap(),
+            http_base_url: Url::parse("http://192.168.1.2:2999/").unwrap(),
+        };
+        let files = BTreeMap::from([(
+            "bin/probe".into(),
+            Url::parse("http://192.168.1.2:2999/share/sessions/session-shell-test/bin/probe")
+                .unwrap(),
+        )]);
+        expand_board_session_variables(&mut config, &context, &files).unwrap();
+        let command = config.shell_init_cmd.as_deref().unwrap();
+        let path = format!(
+            "{}:{}",
+            tools.path().display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+
+        let success = Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .env("PATH", &path)
+            .output()
+            .unwrap();
+        assert!(success.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&success.stdout).trim(),
+            "PROBE_ARG=argument with spaces"
+        );
+
+        let failure = Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .env("PATH", &path)
+            .env("OSTOOL_FAKE_PROGRAM_EXIT", "7")
+            .output()
+            .unwrap();
+        assert!(failure.status.success());
+        assert!(
+            String::from_utf8_lossy(&failure.stdout)
+                .lines()
+                .any(|line| line == SESSION_PROGRAM_FAILURE_MARKER)
+        );
+
+        let session_root = std::path::Path::new("/tmp/ostool-session/session-shell-test");
+        if session_root.exists() {
+            fs::remove_dir_all(session_root).unwrap();
+        }
     }
 }

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -2281,6 +2281,7 @@ interface = "eth0"
         let config = UbootConfig::from_board_run_config(&BoardRunConfig {
             board_type: "rk3568".into(),
             session_files: Vec::new(),
+            session_program: None,
             dtb_file: Some("/tmp/board.dtb".into()),
             kernel_load_addr: Some("0x80200000".into()),
             fit_load_addr: Some("0x82200000".into()),

--- a/ostool/tests/ui/pass_module_level_apis.rs
+++ b/ostool/tests/ui/pass_module_level_apis.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use ostool::{
-    board::{self, config::BoardRunConfig},
+    board::{
+        self, BoardRunRequest,
+        config::{BoardRunConfig, BoardSessionProgram},
+    },
     build::{
         self, CargoBuildOutput, CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs,
         RuntimeArtifactInput,
@@ -36,8 +39,18 @@ fn main() {
     let uboot_config: UbootConfig = uboot::default_config();
     let board_config = BoardRunConfig {
         board_type: "rk3568".into(),
+        shell_prefix: Some("root@board:".into()),
+        session_program: Some(BoardSessionProgram {
+            path: "bin/probe".into(),
+            args: vec!["--server=${boardServerIp}".into()],
+        }),
         ..BoardRunConfig::default()
     };
+    let board_request = BoardRunRequest::new(
+        board_config.clone(),
+        board::RunBoardOptions::default(),
+    );
+    let _ = board_request.with_session_root(Path::new("."));
     let qemu_runner = CargoRunnerKind::new_qemu(CargoQemuRunnerArgs {
         qemu: Some(qemu_config.clone()),
         debug: false,


### PR DESCRIPTION
## 问题

已有 session HTTP 共享要求每个板卡用例重复编写下载、重试、赋权和执行脚本。对于只需运行一个测试程序的用例，这种配置冗长，也容易让本地路径、上传路径和板端路径失配。

## 改动

- 新增具名 Serde 类型 `BoardSessionProgram`，在 `BoardRunConfig` 中声明程序相对路径和 argv。
- 新增 `BoardRunRequest::with_session_root`，统一收集 `session_files` 与 `session_program.path`，保持原相对路径且不支持 alias 或改名。
- session 建立后自动生成板端执行流程：在 session 专属目录中下载全部文件、最多重试 60 秒、依次使用 curl/wget、为程序赋权并以安全 POSIX argv 编码执行。
- argv 支持现有板端 session 变量；程序路径禁止变量，并复用已有绝对路径、`..`、重复路径、符号链接逃逸检查。
- 下载、赋权或非零退出输出内部唯一失败标志，继续复用既有匹配器和 session release 生命周期。
- 保留现有 `with_session_files` 与手写 `shell_init_cmd` 用法；`session_program` 与 `shell_init_cmd` 明确互斥。

## 设计逻辑

协议和服务端保持不变：程序仍是现有 session 共享文件，只在 client 侧把 typed 配置转换为既有上传和 shell-init 行为。因此 ostool-server 0.5.0 可继续运行，无需升级。路径从本地 session root 到 HTTP URL 和板端目录始终一致，避免额外的远端名称映射。

## 验证

- 先加入 API/配置测试并确认旧实现编译失败，再实现功能。
- `cargo fmt --all`
- `cargo test -p ostool -p ostool-server --no-fail-fast`
- `cargo clippy -p ostool -p ostool-server --all-targets -- -D warnings`

## 非目标

- 不修改 HTTP 协议或 ostool-server。
- 不为复杂多步骤用例替代现有 `shell_init_cmd`。