### PR TITLE
fix(uboot-shell): detect split interrupt prompt

### DIFF
--- a/uboot-shell/CHANGELOG.md
+++ b/uboot-shell/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Detect U-Boot prompts printed on the line after the interrupt marker.
+
 ## [0.2.6](https://github.com/drivercraft/ostool/compare/uboot-shell-v0.2.5...uboot-shell-v0.2.6) - 2026-06-25
 
 ### Fixed

--- a/uboot-shell/src/lib.rs
+++ b/uboot-shell/src/lib.rs
@@ -110,25 +110,44 @@ impl UbootShell {
         Ok(interrupt_line)
     }
 
-    async fn clear_shell(&mut self) -> Result<()> {
+    async fn read_until_idle(&mut self) -> Result<Vec<u8>> {
+        let mut bytes = Vec::new();
         loop {
             match self
                 .read_byte_with_timeout(Duration::from_millis(300))
                 .await
             {
-                Ok(_) => {}
-                Err(err) if err.kind() == ErrorKind::TimedOut => return Ok(()),
+                Ok(byte) => bytes.push(byte),
+                Err(err) if err.kind() == ErrorKind::TimedOut => return Ok(bytes),
                 Err(err) => return Err(err),
             }
         }
+    }
+
+    async fn clear_shell(&mut self) -> Result<()> {
+        self.read_until_idle().await.map(|_| ())
     }
 
     async fn wait_for_shell(&mut self) -> Result<()> {
         let mut line = self.wait_for_interrupt().await?;
         debug!("got {}", String::from_utf8_lossy(&line));
         line.resize(line.len().saturating_sub(INT.len()), 0);
-        self.perfix = String::from_utf8_lossy(&line).to_string();
-        self.clear_shell().await?;
+        if line.is_empty() {
+            let prompt = self.read_until_idle().await?;
+            let prompt = String::from_utf8_lossy(&prompt);
+            self.perfix = prompt
+                .lines()
+                .rev()
+                .find(|line| !line.trim().is_empty())
+                .unwrap_or_default()
+                .to_string();
+            if self.perfix.is_empty() {
+                return Err(Error::new(ErrorKind::InvalidData, "U-Boot prompt is empty"));
+            }
+        } else {
+            self.perfix = String::from_utf8_lossy(&line).to_string();
+            self.clear_shell().await?;
+        }
         Ok(())
     }
 
@@ -431,6 +450,103 @@ mod tests {
         fs,
         sync::{Arc, Mutex},
     };
+
+    #[derive(Clone)]
+    struct InterruptTx {
+        response: Arc<Mutex<VecDeque<u8>>>,
+        interrupt_output: &'static [u8],
+    }
+
+    impl AsyncWrite for InterruptTx {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize>> {
+            if buf == [CTRL_C] {
+                self.response.lock().unwrap().extend(self.interrupt_output);
+            }
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    struct InterruptRx {
+        response: Arc<Mutex<VecDeque<u8>>>,
+    }
+
+    impl AsyncRead for InterruptRx {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>> {
+            let mut response = self.response.lock().unwrap();
+            if response.is_empty() {
+                return Poll::Pending;
+            }
+            let count = buf.len().min(response.len());
+            for slot in &mut buf[..count] {
+                *slot = response.pop_front().unwrap();
+            }
+            Poll::Ready(Ok(count))
+        }
+    }
+
+    #[tokio::test]
+    async fn detects_prompt_printed_before_interrupt_marker() -> Result<()> {
+        let response = Arc::new(Mutex::new(VecDeque::new()));
+        let shell = UbootShell::new(
+            InterruptTx {
+                response: response.clone(),
+                interrupt_output: b"=> <INTERRUPT>\n=> ",
+            },
+            InterruptRx { response },
+        )
+        .await?;
+
+        assert_eq!(shell.perfix, "=> ");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn detects_prompt_printed_after_interrupt_line() -> Result<()> {
+        let response = Arc::new(Mutex::new(VecDeque::new()));
+        let shell = UbootShell::new(
+            InterruptTx {
+                response: response.clone(),
+                interrupt_output: b"<INTERRUPT>\n=> ",
+            },
+            InterruptRx { response },
+        )
+        .await?;
+
+        assert_eq!(shell.perfix, "=> ");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn detects_prompt_after_repeated_interrupt_output() -> Result<()> {
+        let response = Arc::new(Mutex::new(VecDeque::new()));
+        let shell = UbootShell::new(
+            InterruptTx {
+                response: response.clone(),
+                interrupt_output: b"<INTERRUPT>\n=> <INTERRUPT>\n=> ",
+            },
+            InterruptRx { response },
+        )
+        .await?;
+
+        assert_eq!(shell.perfix, "=> ");
+        Ok(())
+    }
 
     #[derive(Default)]
     struct LoadyScript {


### PR DESCRIPTION
## 问题

`uboot-shell 0.2.6` 假定 U-Boot 中断输出为 `=> <INTERRUPT>\n`，并从 `<INTERRUPT>` 同一行提取提示符。Orange Pi 5 Plus 上的 U-Boot 2025.10 实际输出为 `<INTERRUPT>\n=> `，导致保存的提示符为空，后续命令只读取首个字符便被误判为完成。

## 修改

- 抽取按串口空闲边界收集输出的辅助方法。
- 当中断标记前没有提示符时，从后续输出中提取提示符，并去除行首换行。
- 保留提示符与中断标记同行的既有行为。
- 对空提示符返回明确错误，避免继续执行产生误导性结果。
- 增加两种输出布局的确定性回归测试，并更新 Unreleased changelog。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy -p uboot-shell --all-targets --all-features -- -D warnings`
- `cargo build -p uboot-shell --all-features`
- `cargo test -p uboot-shell -- --nocapture --test-threads=1`
- Orange Pi 5 Plus（RK3588，U-Boot 2025.10，CH340 串口 1500000 baud）实机验证：通过本地依赖覆盖运行 `ostool 0.23.5`，成功识别分行提示符，连续执行 `setenv autoload yes`、读取加载地址、生成 FIT，并进入 `loady` 上传阶段。

## 发布请求

此修复解决已发布 `uboot-shell 0.2.6` 与上述 U-Boot 输出格式的兼容问题。合并后请发布 **`uboot-shell 0.2.7`**，以便 `ostool` 和下游项目直接更新到修复版本。