### PR TITLE
feat(ostool): expose variable and OVMF cache APIs

### DIFF
--- a/ostool/src/lib.rs
+++ b/ostool/src/lib.rs
@@ -19,9 +19,11 @@
 //! - [`build`] - Build system configuration and Cargo integration
 //! - [`invocation`] - Invocation inputs and resolved project layout
 //! - [`menuconfig`] - TUI-based menu configuration
+//! - [`ovmf`] - Verified prebuilt OVMF firmware cache
 //! - [`run`] - QEMU, TFTP, and U-Boot runners
 //! - [`sterm`] - Serial terminal implementation
 //! - [`utils`] - Common utilities and helper functions
+//! - [`variables`] - Workspace, package, temporary, and environment variable expansion
 //!
 //! ## Example
 //!
@@ -62,6 +64,9 @@ pub mod logger;
 /// build options through an interactive terminal interface.
 pub mod menuconfig;
 
+/// Verified prebuilt OVMF firmware cache.
+pub mod ovmf;
+
 mod project;
 
 mod process;
@@ -80,6 +85,9 @@ pub mod sterm;
 
 /// Common utilities and helper functions.
 pub mod utils;
+
+/// Workspace, package, temporary, and environment variable expansion.
+pub mod variables;
 
 #[macro_use]
 extern crate log;

--- a/ostool/src/ovmf.rs
+++ b/ostool/src/ovmf.rs
@@ -1,0 +1,26 @@
+//! Verified prebuilt OVMF firmware cache.
+
+use std::path::PathBuf;
+
+pub use crate::run::ovmf_prebuilt::{Arch, Error, FileType, Prebuilt, Source};
+
+/// Returns the shared OVMF cache directory.
+///
+/// All ostool consumers use `$TMPDIR/ostool/ovmf`, where `$TMPDIR` is the
+/// platform temporary directory selected by [`std::env::temp_dir`].
+pub fn default_cache_dir() -> PathBuf {
+    std::env::temp_dir().join("ostool").join("ovmf")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_cache_is_owned_by_ostool() {
+        assert_eq!(
+            default_cache_dir(),
+            std::env::temp_dir().join("ostool").join("ovmf")
+        );
+    }
+}

--- a/ostool/src/project/variables.rs
+++ b/ostool/src/project/variables.rs
@@ -28,7 +28,7 @@ impl VariableScope {
     }
 
     /// Builds a variable scope for a specific Cargo package directory.
-    pub fn for_package(layout: &ProjectLayout, package_dir: PathBuf) -> Self {
+    pub(crate) fn for_package(layout: &ProjectLayout, package_dir: PathBuf) -> Self {
         Self::new(
             layout.workspace_dir().to_path_buf(),
             package_dir,

--- a/ostool/src/run/mod.rs
+++ b/ostool/src/run/mod.rs
@@ -34,8 +34,8 @@ mod output_matcher;
 
 pub use output_matcher::{ByteStreamMatcher, StreamMatch, StreamMatchKind};
 
-/// OVMF prebuilt firmware downloader (internal).
-mod ovmf_prebuilt;
+/// OVMF prebuilt firmware downloader backing the public cache API.
+pub(crate) mod ovmf_prebuilt;
 
 /// Shared shell auto-init matcher and delayed command sender.
 pub(crate) mod shell_init;

--- a/ostool/src/run/qemu.rs
+++ b/ostool/src/run/qemu.rs
@@ -50,13 +50,13 @@ use crate::{
     boot::artifacts::{default_qemu_dtb_dump_path, prepare_qemu_dtb_dump},
     build::config::Cargo,
     invocation::Invocation,
+    ovmf::{Arch, FileType, Prebuilt, Source, default_cache_dir},
     process::ProcessContext,
     project::variables::{self, VariableScope},
     project::{ProjectLayout, metadata},
     run::{
         execution::{RunnerExecutionSummary, RunnerExitStatus, timeout_duration},
         output_matcher::{ByteStreamMatcher, compile_regexes, print_match_event},
-        ovmf_prebuilt::{Arch, FileType, Prebuilt, Source},
         qemu_plan::{QemuBootSource, QemuCommandPlanInput, build_qemu_command_plan},
         shell_init::{
             SHELL_INIT_CHUNK_DELAY, SHELL_INIT_CHUNK_SIZE, SHELL_INIT_DELAY, ShellAutoInitMatcher,
@@ -611,8 +611,7 @@ impl QemuRunner {
             .input
             .arch
             .ok_or_else(|| anyhow::anyhow!("Cannot determine architecture for OVMF preparation"))?;
-        let tmp = std::env::temp_dir();
-        let bios_dir = tmp.join("ostool").join("ovmf");
+        let bios_dir = default_cache_dir();
         fs::create_dir_all(&bios_dir)
             .await
             .with_path("failed to create directory", &bios_dir)?;

--- a/ostool/src/variables.rs
+++ b/ostool/src/variables.rs
@@ -1,0 +1,3 @@
+//! Workspace, package, temporary, and environment variable expansion.
+
+pub use crate::project::variables::{VariableScope, expand_path_variables, expand_variables};

--- a/ostool/tests/ui/pass_module_level_apis.rs
+++ b/ostool/tests/ui/pass_module_level_apis.rs
@@ -8,13 +8,26 @@ use ostool::{
         config::{BuildConfig, BuildSystem, Cargo, Custom},
     },
     invocation::{Invocation, InvocationOptions},
+    ovmf::{Arch, FileType, Prebuilt, Source, default_cache_dir},
     run::{
         qemu::{self, QemuConfig, RunQemuOptions},
         uboot::{self, UbootConfig},
     },
+    variables::{VariableScope, expand_path_variables, expand_variables},
 };
 
+fn assert_prebuilt_api(prebuilt: &Prebuilt) {
+    let _ = prebuilt.get_file(Arch::X64, FileType::Code);
+}
+
 fn main() {
+    let scope = VariableScope::new("workspace".into(), "package".into(), "tmp".into());
+    let _ = expand_variables("${workspace}", &scope).unwrap();
+    let _ = expand_path_variables(Path::new("${tmpDir}/asset"), &scope).unwrap();
+    let _ = default_cache_dir();
+    let _ = Source::LATEST;
+    let _ = assert_prebuilt_api;
+
     let mut invocation = Invocation::new(InvocationOptions::default()).unwrap();
     let cargo = Cargo {
         package: "kernel".into(),


### PR DESCRIPTION
## 问题

下游项目已经在使用 Ostool 的变量语法和 OVMF 预构建缓存，但这两项能力仍位于私有模块中。调用方只能重复实现路径展开，或自行约定 `$TMPDIR/ostool/ovmf`、扫描系统固件路径，容易造成版本选择、校验与缓存语义不一致。

## 修改

- 新增 `ostool::variables` 公共入口，公开 `VariableScope`、`expand_variables` 和 `expand_path_variables`。
- 将依赖私有 `ProjectLayout` 的 `VariableScope::for_package` 收窄为 crate 内部接口。
- 新增 `ostool::ovmf` 公共入口，公开 `default_cache_dir`、`Arch`、`FileType`、`Prebuilt`、`Source` 及对应错误类型。
- 由 `default_cache_dir()` 统一拥有 `$TMPDIR/ostool/ovmf` 路径约定。
- Ostool 自身 QEMU UEFI 准备流程改用该公共入口，继续复用既有固定版本、SHA-256 校验、镜像探测和离线缓存实现。
- 扩展外部 crate 编译测试，保证新增 API 可以从包外使用。

## 实现逻辑

公共模块仅作为稳定 facade 重导出现有实现，不复制变量解析器或 OVMF 下载器。这样既不暴露内部 `ProjectLayout` 和 runner 组织结构，也让 Ostool 自身与下游共享同一个缓存所有者及校验流程。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p ostool --lib --test public_api -- --nocapture`（259 个库测试及 public API trybuild 通过）
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features -- -D warnings`
